### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/annotations/dsl/src/main/java/io/sundr/dsl/internal/graph/functions/ToNext.java
+++ b/annotations/dsl/src/main/java/io/sundr/dsl/internal/graph/functions/ToNext.java
@@ -40,7 +40,7 @@ public class ToNext implements Function<NodeContext, Set<JavaClazz>> {
         Set<JavaClazz> result = new LinkedHashSet<JavaClazz>();
         Boolean inScope = !context.getActiveScopes().isEmpty();
 
-        if ((inScope && isEndScope(context.getItem()) || isTerminal(context.getItem()))) {
+        if (inScope && isEndScope(context.getItem()) || isTerminal(context.getItem())) {
           return result;
         }
 

--- a/codegen/src/main/java/io/sundr/codegen/model/JavaType.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/JavaType.java
@@ -100,8 +100,8 @@ public class JavaType extends AttributeSupport implements Type {
     }
 
     public boolean isBoolean() {
-        return (("boolean".equals(className)) ||
-                ("Boolean".equals(className)));
+        return ("boolean".equals(className)) ||
+               ("Boolean".equals(className));
     }
 
     public JavaKind getKind() {

--- a/core/src/main/java/io/sundr/SundrException.java
+++ b/core/src/main/java/io/sundr/SundrException.java
@@ -36,9 +36,9 @@ public class SundrException extends RuntimeException {
 
     public RuntimeException launderThrowable(Throwable cause) {
         if (cause instanceof RuntimeException) {
-            return ((RuntimeException) cause);
+            return (RuntimeException) cause;
         } else if (cause instanceof Error) {
-            throw ((Error) cause);
+            throw (Error) cause;
         } else {
             throw new SundrException("An error has occurred.", cause);
         }

--- a/examples/codegen/src/main/java/io/sundr/examples/codegen/JavaType.java
+++ b/examples/codegen/src/main/java/io/sundr/examples/codegen/JavaType.java
@@ -100,8 +100,8 @@ public class JavaType extends AttributeSupport implements Type {
     }
 
     public boolean isBoolean() {
-        return (("boolean".equals(className)) ||
-                ("Boolean".equals(className)));
+        return ("boolean".equals(className)) ||
+               ("Boolean".equals(className));
     }
 
     public JavaKind getKind() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed