### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/Constants.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/Constants.java
@@ -32,6 +32,8 @@ import static io.sundr.codegen.utils.TypeUtils.newGeneric;
 import static io.sundr.codegen.utils.TypeUtils.typeGenericOf;
 
 public class Constants {
+    
+    private Constants() {}
 
     public static final String DEFAULT_BUILDER_PACKAGE = "io.sundr.builder";
 

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/BuilderContextManager.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/BuilderContextManager.java
@@ -23,6 +23,8 @@ import javax.lang.model.util.Elements;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class BuilderContextManager {
+    
+    private BuilderContextManager() {}
 
     private static final AtomicReference<BuilderContext> context = new AtomicReference<BuilderContext>();
 

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/PropertyAs.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/PropertyAs.java
@@ -47,6 +47,8 @@ import static io.sundr.codegen.utils.StringUtils.captializeFirst;
 import static io.sundr.codegen.utils.TypeUtils.typeExtends;
 
 public final class PropertyAs {
+    
+    private PropertyAs() {}
 
     public static final Function<JavaProperty, JavaClazz> CLASS = new Function<JavaProperty, JavaClazz>() {
         @Override

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/utils/BuilderUtils.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/utils/BuilderUtils.java
@@ -48,6 +48,8 @@ import static io.sundr.builder.Constants.SET;
 import static io.sundr.codegen.utils.TypeUtils.unwrapGeneric;
 
 public class BuilderUtils {
+    
+    private BuilderUtils() {}
 
     public static final String BUILDABLE = "BUILDABLE";
 

--- a/annotations/dsl/src/main/java/io/sundr/dsl/internal/Constants.java
+++ b/annotations/dsl/src/main/java/io/sundr/dsl/internal/Constants.java
@@ -20,6 +20,8 @@ import io.sundr.codegen.model.JavaType;
 import io.sundr.codegen.model.JavaTypeBuilder;
 
 public final class Constants {
+    
+    private Constants() {}
 
     public static final String[] REMOVABLE_PREFIXES = {"With"};
     public static final String INTERFACE_SUFFIX = "Interface";

--- a/annotations/dsl/src/main/java/io/sundr/dsl/internal/type/functions/Merge.java
+++ b/annotations/dsl/src/main/java/io/sundr/dsl/internal/type/functions/Merge.java
@@ -27,6 +27,8 @@ import io.sundr.codegen.model.JavaTypeBuilder;
 import java.util.Arrays;
 
 public final class Merge {
+    
+    private Merge() {}
 
     public static final Function<JavaType[], JavaType> TYPES = new Function<JavaType[], JavaType>() {
         @Override

--- a/maven-plugin/src/main/java/io/sundr/maven/Constants.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/Constants.java
@@ -17,6 +17,8 @@
 package io.sundr.maven;
 
 public class Constants {
+    
+    private Constants() {}
 
     public static final String POM_TYPE = "pom";
     public static final String MAVEN_PLUGIN_TYPE = "maven-plugin";

--- a/maven-plugin/src/main/java/io/sundr/maven/filter/Filters.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/filter/Filters.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Set;
 
 public class Filters {
+    
+    private Filters() {}
 
     public static final ArtifactFilter MAVEN_PLUGIN_FILTER = new MavenPluginFilter();
     public static final ArtifactFilter EXCLUDE_POM_FILTER = new IncludePomsFilter(false);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed