### PR TITLE
Code quality fix - "equals(Object obj)" and "hashCode()" should be overridden in pairs.

### DIFF
--- a/codegen/src/main/java/io/sundr/codegen/model/JavaClazzBuilder.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/JavaClazzBuilder.java
@@ -41,6 +41,15 @@ validate(buildable);
 return buildable;
 
 }
+
+@Override
+public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((fluent == null) ? 0 : fluent.hashCode());
+    return result;
+}
+
 public boolean equals( Object o ){
     
 if (this == o) return true;

--- a/codegen/src/main/java/io/sundr/codegen/model/JavaClazzFluent.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/JavaClazzFluent.java
@@ -168,20 +168,38 @@ public class JavaClazzFluent<T extends JavaClazzFluent<T>> extends AttributeSupp
     public NestedNested<T> addNewNestedLike( JavaClazz item){
     return new NestedNested<T>(item);
     }
-    public boolean equals( Object o){
+   
     
-if (this == o) return true;
-if (o == null || getClass() != o.getClass()) return false;
-if (!super.equals(o)) return false;
-JavaClazzFluent that = (JavaClazzFluent) o;
-if (type != null ? !type.equals(that.type) :that.type != null) return false;
-if (annotations != null ? !annotations.equals(that.annotations) :that.annotations != null) return false;
-if (methods != null ? !methods.equals(that.methods) :that.methods != null) return false;
-if (constructors != null ? !constructors.equals(that.constructors) :that.constructors != null) return false;
-if (fields != null ? !fields.equals(that.fields) :that.fields != null) return false;
-if (imports != null ? !imports.equals(that.imports) :that.imports != null) return false;
-if (nested != null ? !nested.equals(that.nested) :that.nested != null) return false;
-return true;
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((annotations == null) ? 0 : annotations.hashCode());
+        result = prime * result
+                + ((constructors == null) ? 0 : constructors.hashCode());
+        result = prime * result + ((fields == null) ? 0 : fields.hashCode());
+        result = prime * result + ((imports == null) ? 0 : imports.hashCode());
+        result = prime * result + ((methods == null) ? 0 : methods.hashCode());
+        result = prime * result + ((nested == null) ? 0 : nested.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
+    
+    public boolean equals( Object o){
+        
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        JavaClazzFluent that = (JavaClazzFluent) o;
+        if (type != null ? !type.equals(that.type) :that.type != null) return false;
+        if (annotations != null ? !annotations.equals(that.annotations) :that.annotations != null) return false;
+        if (methods != null ? !methods.equals(that.methods) :that.methods != null) return false;
+        if (constructors != null ? !constructors.equals(that.constructors) :that.constructors != null) return false;
+        if (fields != null ? !fields.equals(that.fields) :that.fields != null) return false;
+        if (imports != null ? !imports.equals(that.imports) :that.imports != null) return false;
+        if (nested != null ? !nested.equals(that.nested) :that.nested != null) return false;
+        return true;
 
     }
 

--- a/codegen/src/main/java/io/sundr/codegen/model/JavaMethodBuilder.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/JavaMethodBuilder.java
@@ -41,6 +41,15 @@ validate(buildable);
 return buildable;
 
 }
+
+@Override
+public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((fluent == null) ? 0 : fluent.hashCode());
+    return result;
+}
+
 public boolean equals( Object o ){
     
 if (this == o) return true;

--- a/codegen/src/main/java/io/sundr/codegen/model/JavaMethodBuilder.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/JavaMethodBuilder.java
@@ -41,15 +41,6 @@ validate(buildable);
 return buildable;
 
 }
-
-@Override
-public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((fluent == null) ? 0 : fluent.hashCode());
-    return result;
-}
-
 public boolean equals( Object o ){
     
 if (this == o) return true;

--- a/codegen/src/main/java/io/sundr/codegen/model/JavaMethodFluent.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/JavaMethodFluent.java
@@ -21,6 +21,7 @@ import io.sundr.builder.Nested;
 import io.sundr.builder.VisitableBuilder;
 
 import javax.lang.model.element.Modifier;
+
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -152,20 +153,41 @@ return result.toArray(new JavaProperty[result.size()]);
     public ExceptionsNested<T> addNewExceptionLike( JavaType item){
     return new ExceptionsNested<T>(item);
     }
-    public boolean equals( Object o){
     
-if (this == o) return true;
-if (o == null || getClass() != o.getClass()) return false;
-if (!super.equals(o)) return false;
-JavaMethodFluent that = (JavaMethodFluent) o;
-if (annotations != null ? !annotations.equals(that.annotations) :that.annotations != null) return false;
-if (modifiers != null ? !modifiers.equals(that.modifiers) :that.modifiers != null) return false;
-if (typeParameters != null ? !typeParameters.equals(that.typeParameters) :that.typeParameters != null) return false;
-if (name != null ? !name.equals(that.name) :that.name != null) return false;
-if (returnType != null ? !returnType.equals(that.returnType) :that.returnType != null) return false;
-if (arguments != null ? !arguments.equals(that.arguments) :that.arguments != null) return false;
-if (exceptions != null ? !exceptions.equals(that.exceptions) :that.exceptions != null) return false;
-return true;
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((annotations == null) ? 0 : annotations.hashCode());
+        result = prime * result
+                + ((arguments == null) ? 0 : arguments.hashCode());
+        result = prime * result
+                + ((exceptions == null) ? 0 : exceptions.hashCode());
+        result = prime * result
+                + ((modifiers == null) ? 0 : modifiers.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result
+                + ((returnType == null) ? 0 : returnType.hashCode());
+        result = prime * result
+                + ((typeParameters == null) ? 0 : typeParameters.hashCode());
+        return result;
+    }
+    
+    public boolean equals( Object o){
+        
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        JavaMethodFluent that = (JavaMethodFluent) o;
+        if (annotations != null ? !annotations.equals(that.annotations) :that.annotations != null) return false;
+        if (modifiers != null ? !modifiers.equals(that.modifiers) :that.modifiers != null) return false;
+        if (typeParameters != null ? !typeParameters.equals(that.typeParameters) :that.typeParameters != null) return false;
+        if (name != null ? !name.equals(that.name) :that.name != null) return false;
+        if (returnType != null ? !returnType.equals(that.returnType) :that.returnType != null) return false;
+        if (arguments != null ? !arguments.equals(that.arguments) :that.arguments != null) return false;
+        if (exceptions != null ? !exceptions.equals(that.exceptions) :that.exceptions != null) return false;
+        return true;
 
     }
 

--- a/codegen/src/main/java/io/sundr/codegen/model/JavaPropertyBuilder.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/JavaPropertyBuilder.java
@@ -41,6 +41,15 @@ validate(buildable);
 return buildable;
 
 }
+
+@Override
+public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((fluent == null) ? 0 : fluent.hashCode());
+    return result;
+}
+
 public boolean equals( Object o ){
     
 if (this == o) return true;

--- a/codegen/src/main/java/io/sundr/codegen/model/JavaPropertyFluent.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/JavaPropertyFluent.java
@@ -21,6 +21,7 @@ import io.sundr.builder.Nested;
 import io.sundr.builder.VisitableBuilder;
 
 import javax.lang.model.element.Modifier;
+
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -91,18 +92,33 @@ public class JavaPropertyFluent<T extends JavaPropertyFluent<T>> extends Attribu
     public T withArray( boolean array){
     this.array=array; return (T) this;
     }
-    public boolean equals( Object o){
     
-if (this == o) return true;
-if (o == null || getClass() != o.getClass()) return false;
-if (!super.equals(o)) return false;
-JavaPropertyFluent that = (JavaPropertyFluent) o;
-if (annotations != null ? !annotations.equals(that.annotations) :that.annotations != null) return false;
-if (modifiers != null ? !modifiers.equals(that.modifiers) :that.modifiers != null) return false;
-if (type != null ? !type.equals(that.type) :that.type != null) return false;
-if (name != null ? !name.equals(that.name) :that.name != null) return false;
-if (array != that.array) return false;
-return true;
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((annotations == null) ? 0 : annotations.hashCode());
+        result = prime * result + (array ? 1231 : 1237);
+        result = prime * result
+                + ((modifiers == null) ? 0 : modifiers.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
+    
+    public boolean equals( Object o){
+        
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        JavaPropertyFluent that = (JavaPropertyFluent) o;
+        if (annotations != null ? !annotations.equals(that.annotations) :that.annotations != null) return false;
+        if (modifiers != null ? !modifiers.equals(that.modifiers) :that.modifiers != null) return false;
+        if (type != null ? !type.equals(that.type) :that.type != null) return false;
+        if (name != null ? !name.equals(that.name) :that.name != null) return false;
+        if (array != that.array) return false;
+        return true;
 
     }
 

--- a/codegen/src/main/java/io/sundr/codegen/model/JavaTypeBuilder.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/JavaTypeBuilder.java
@@ -41,6 +41,15 @@ validate(buildable);
 return buildable;
 
 }
+
+@Override
+public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((fluent == null) ? 0 : fluent.hashCode());
+    return result;
+}
+
 public boolean equals( Object o ){
     
 if (this == o) return true;

--- a/codegen/src/main/java/io/sundr/codegen/model/JavaTypeFluent.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/JavaTypeFluent.java
@@ -139,23 +139,49 @@ return result.toArray(new JavaType[result.size()]);
     public GenericTypesNested<T> addNewGenericTypeLike( JavaType item){
     return new GenericTypesNested<T>(item);
     }
-    public boolean equals( Object o){
     
-if (this == o) return true;
-if (o == null || getClass() != o.getClass()) return false;
-if (!super.equals(o)) return false;
-JavaTypeFluent that = (JavaTypeFluent) o;
-if (kind != null ? !kind.equals(that.kind) :that.kind != null) return false;
-if (packageName != null ? !packageName.equals(that.packageName) :that.packageName != null) return false;
-if (className != null ? !className.equals(that.className) :that.className != null) return false;
-if (array != that.array) return false;
-if (collection != that.collection) return false;
-if (concrete != that.concrete) return false;
-if (defaultImplementation != null ? !defaultImplementation.equals(that.defaultImplementation) :that.defaultImplementation != null) return false;
-if (superClass != null ? !superClass.equals(that.superClass) :that.superClass != null) return false;
-if (interfaces != null ? !interfaces.equals(that.interfaces) :that.interfaces != null) return false;
-if (genericTypes != null ? !genericTypes.equals(that.genericTypes) :that.genericTypes != null) return false;
-return true;
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (array ? 1231 : 1237);
+        result = prime * result
+                + ((className == null) ? 0 : className.hashCode());
+        result = prime * result + (collection ? 1231 : 1237);
+        result = prime * result + (concrete ? 1231 : 1237);
+        result = prime
+                * result
+                + ((defaultImplementation == null) ? 0 : defaultImplementation
+                        .hashCode());
+        result = prime * result
+                + ((genericTypes == null) ? 0 : genericTypes.hashCode());
+        result = prime * result
+                + ((interfaces == null) ? 0 : interfaces.hashCode());
+        result = prime * result + ((kind == null) ? 0 : kind.hashCode());
+        result = prime * result
+                + ((packageName == null) ? 0 : packageName.hashCode());
+        result = prime * result
+                + ((superClass == null) ? 0 : superClass.hashCode());
+        return result;
+    }
+    
+    public boolean equals( Object o){
+        
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        JavaTypeFluent that = (JavaTypeFluent) o;
+        if (kind != null ? !kind.equals(that.kind) :that.kind != null) return false;
+        if (packageName != null ? !packageName.equals(that.packageName) :that.packageName != null) return false;
+        if (className != null ? !className.equals(that.className) :that.className != null) return false;
+        if (array != that.array) return false;
+        if (collection != that.collection) return false;
+        if (concrete != that.concrete) return false;
+        if (defaultImplementation != null ? !defaultImplementation.equals(that.defaultImplementation) :that.defaultImplementation != null) return false;
+        if (superClass != null ? !superClass.equals(that.superClass) :that.superClass != null) return false;
+        if (interfaces != null ? !interfaces.equals(that.interfaces) :that.interfaces != null) return false;
+        if (genericTypes != null ? !genericTypes.equals(that.genericTypes) :that.genericTypes != null) return false;
+        return true;
 
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1206- "equals(Object obj)" and "hashCode()" should be overridden in pairs
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1206

Please let me know if you have any questions.

Faisal Hameed