### PR TITLE
Adding support for external imported BOMs

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -62,6 +62,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${maven-plugin-plugin-version}</version>
+                <executions>
+                    <execution>
+                        <id>default-descriptor</id>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/maven-plugin/src/it/multimodule/custom.xml.vm
+++ b/maven-plugin/src/it/multimodule/custom.xml.vm
@@ -82,7 +82,16 @@
 
                 <type>${d.type}</type>#end#if( $d.classifier && $!d.classifier != '' )
 
-                <classifier>${d.classifier}</classifier>#end
+                <classifier>${d.classifier}</classifier>#end#if( $d.exclusions && $d.exclusions.size() > 0 )
+
+                <exclusions>#foreach( $e in $d.exclusions )
+
+                    <exclusion>
+                        <groupId>${e.groupId}</groupId>
+                        <artifactId>${e.artifactId}</artifactId>
+                    </exclusion>#end
+
+                </exclusions>#end
 
             </dependency>#end
 

--- a/maven-plugin/src/it/multimodule/pom.xml
+++ b/maven-plugin/src/it/multimodule/pom.xml
@@ -129,6 +129,95 @@
                                 </excludes>
                             </goals>
                         </bom>
+                        <bom>
+                            <artifactId>bom-test-7</artifactId>
+                            <name>Test Project :: Bom 7</name>
+                            <modules>
+                                <excludes>
+                                    <exclude>*:*</exclude>
+                                </excludes>
+                            </modules>
+                            <dependencies>
+                                <includes>
+                                    <include>io.sundr:*</include>
+                                </includes>
+                            </dependencies>
+                            <imports>
+                                <import>
+                                    <groupId>org.springframework.boot</groupId>
+                                    <artifactId>spring-boot-dependencies</artifactId>
+                                    <version>1.4.1.RELEASE</version>
+                                    <dependencyManagement>
+                                        <includes>
+                                            <include>*:*</include>
+                                        </includes>
+                                    </dependencyManagement>
+                                </import>
+                                <import>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-parent</artifactId>
+                                    <version>2.17.2</version>
+                                    <dependencyManagement>
+                                        <includes>
+                                            <include>*:*</include>
+                                        </includes>
+                                    </dependencyManagement>
+                                </import>
+                            </imports>
+                            <goals>
+                                <excludes>
+                                    <exclude>deploy</exclude>
+                                </excludes>
+                            </goals>
+                            <failOnMismatch>false</failOnMismatch>
+                        </bom>
+                        <bom>
+                            <artifactId>bom-test-8</artifactId>
+                            <name>Test Project :: Bom 8</name>
+                            <modules>
+                                <excludes>
+                                    <exclude>*:*</exclude>
+                                </excludes>
+                            </modules>
+                            <dependencies>
+                                <includes>
+                                    <include>io.sundr:*</include>
+                                </includes>
+                            </dependencies>
+                            <imports>
+                                <import>
+                                    <groupId>org.springframework.boot</groupId>
+                                    <artifactId>spring-boot-dependencies</artifactId>
+                                    <version>1.4.1.RELEASE</version>
+                                    <dependencyManagement>
+                                        <includes>
+                                            <include>*:*</include>
+                                        </includes>
+                                        <excludes>
+                                            <exclude>com.google.code.gson:gson</exclude>
+                                        </excludes>
+                                    </dependencyManagement>
+                                </import>
+                                <import>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-parent</artifactId>
+                                    <version>2.17.3</version>
+                                    <dependencyManagement>
+                                        <includes>
+                                            <include>org.apache.camel:*</include>
+                                        </includes>
+                                        <excludes>
+                                            <exclude>org.apache.camel:camel-h*</exclude>
+                                        </excludes>
+                                    </dependencyManagement>
+                                </import>
+                            </imports>
+                            <goals>
+                                <excludes>
+                                    <exclude>deploy</exclude>
+                                </excludes>
+                            </goals>
+                        </bom>
                     </boms>
                 </configuration>
                 <executions>

--- a/maven-plugin/src/it/multimodule/verify.bsh
+++ b/maven-plugin/src/it/multimodule/verify.bsh
@@ -44,6 +44,8 @@ boolean deployed3 = isDeployed("bom-test-3");
 boolean deployed4 = isDeployed("bom-test-4");
 boolean deployed5 = isDeployed("bom-test-5");
 boolean deployed6 = isDeployed("bom-test-6");
+boolean deployed7 = isDeployed("bom-test-7");
+boolean deployed8 = isDeployed("bom-test-8");
 
 boolean parent1 = hasParent("bom-test-1");
 boolean parent2 = hasParent("bom-test-2");
@@ -51,6 +53,8 @@ boolean parent3 = hasParent("bom-test-3");
 boolean parent4 = hasParent("bom-test-4");
 boolean parent5 = hasParent("bom-test-5");
 boolean parent6 = hasParent("bom-test-6");
+boolean parent7 = hasParent("bom-test-7");
+boolean parent8 = hasParent("bom-test-8");
 
 Set deps1 = findDependencies("bom-test-1");
 Set deps2 = findDependencies("bom-test-2");
@@ -58,6 +62,8 @@ Set deps3 = findDependencies("bom-test-3");
 Set deps4 = findDependencies("bom-test-4");
 Set deps5 = findDependencies("bom-test-5");
 Set deps6 = findDependencies("bom-test-6");
+Set deps7 = findDependencies("bom-test-7");
+Set deps8 = findDependencies("bom-test-8");
 
 
 return deployed1 && !parent1 && deps1.size() == 1 && deps1.contains("test:module1") &&
@@ -65,4 +71,6 @@ return deployed1 && !parent1 && deps1.size() == 1 && deps1.contains("test:module
       deployed3 && !parent3 && deps3.size() == 1 && deps3.contains("test:module2") &&
       deployed4 && !parent4 && deps4.size() == 1 && deps4.contains("test:module1") &&
       !deployed5 && !parent5 && deps5.size() == 2 && deps5.contains("test:module2") && deps5.contains("test:module1") &&
-      !deployed6 && !parent6 && deps6.size() == 3 && deps6.contains("test:module2") && deps6.contains("test:module1") && deps6.contains("io.sundr:sundr-core");
+      !deployed6 && !parent6 && deps6.size() == 3 && deps6.contains("test:module2") && deps6.contains("test:module1") && deps6.contains("io.sundr:sundr-core") &&
+      !deployed7 && !parent7 && deps7.size() > 800 && deps7.contains("org.springframework.boot:spring-boot-starter") && deps7.contains("org.apache.camel:camel-http") && deps7.contains("com.google.code.gson:gson") && deps7.contains("io.sundr:sundr-core") &&
+      !deployed8 && !parent8 && deps8.size() < 800 && deps8.contains("org.springframework.boot:spring-boot-starter") && deps8.contains("org.apache.camel:camel-cxf") && !deps8.contains("org.apache.camel:camel-http") && !deps8.contains("com.google.code.gson:gson") && deps8.contains("io.sundr:sundr-core");

--- a/maven-plugin/src/main/java/io/sundr/maven/BomConfig.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/BomConfig.java
@@ -16,6 +16,8 @@
 
 package io.sundr.maven;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Properties;
 
 public class BomConfig {
@@ -26,12 +28,16 @@ public class BomConfig {
     private ArtifactSet modules = new ArtifactSet();
     private ArtifactSet dependencies = new ArtifactSet();
     private ArtifactSet plugins = new ArtifactSet();
+    private List<BomImport> imports = new LinkedList<BomImport>();
     private GoalSet goals = new GoalSet();
     private boolean ignoreScope = true;
     private boolean excludeOptional = true;
 
     private boolean inheritDependencyManagement;
     private boolean inheritPluginManagement;
+
+    private boolean checkMismatches = true;
+    private boolean failOnMismatch = false;
 
     private Properties properties = new Properties();
 
@@ -67,6 +73,10 @@ public class BomConfig {
         return plugins;
     }
 
+    public List<BomImport> getImports() {
+        return imports;
+    }
+
     public GoalSet getGoals() {
         return goals;
     }
@@ -89,5 +99,13 @@ public class BomConfig {
 
     public boolean isInheritPluginManagement() {
         return inheritPluginManagement;
+    }
+
+    public boolean isCheckMismatches() {
+        return checkMismatches;
+    }
+
+    public boolean isFailOnMismatch() {
+        return failOnMismatch;
     }
 }

--- a/maven-plugin/src/main/java/io/sundr/maven/BomImport.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/BomImport.java
@@ -26,6 +26,8 @@ public class BomImport {
 
     private String version;
 
+    private String repository;
+
     private ArtifactSet dependencyManagement = new ArtifactSet();
 
     public BomImport() {
@@ -53,6 +55,14 @@ public class BomImport {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public void setRepository(String repository) {
+        this.repository = repository;
     }
 
     public ArtifactSet getDependencyManagement() {

--- a/maven-plugin/src/main/java/io/sundr/maven/BomImport.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/BomImport.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.sundr.maven;
+
+/**
+ * Information related to an external BOM dependency that should be imported.
+ */
+public class BomImport {
+
+    private String groupId;
+
+    private String artifactId;
+
+    private String version;
+
+    private ArtifactSet dependencyManagement = new ArtifactSet();
+
+    public BomImport() {
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public ArtifactSet getDependencyManagement() {
+        return dependencyManagement;
+    }
+
+    public void setDependencyManagement(ArtifactSet dependencyManagement) {
+        this.dependencyManagement = dependencyManagement;
+    }
+
+    @Override
+    public String toString() {
+        return groupId + ":" + artifactId + ":" + version;
+    }
+}

--- a/maven-plugin/src/main/java/io/sundr/maven/ExternalBomResolver.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/ExternalBomResolver.java
@@ -38,7 +38,7 @@ import org.eclipse.aether.resolution.ArtifactRequest;
 
 /**
  * Resolves external BOMs and provides its managed dependencies.
- * Using Aether to get full information about the managed dependencies.
+ * Using Aether to get full information about the managed dependencies (including versions and transitive imports).
  */
 public class ExternalBomResolver {
 
@@ -64,6 +64,13 @@ public class ExternalBomResolver {
         this.logger = logger;
     }
 
+    /**
+     * Resolve all imports contained in the given configuration.
+     *
+     * @param config the Bom configuration
+     * @return all artifacts and related dependencies imported from external Boms
+     * @throws Exception in case of resolution failure
+     */
     public Map<Artifact, Dependency> resolve(BomConfig config) throws Exception {
         Map<Artifact, Dependency> dependencies = new LinkedHashMap<Artifact, Dependency>();
         if (config != null && config.getImports() != null) {

--- a/maven-plugin/src/main/java/io/sundr/maven/ExternalBomResolver.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/ExternalBomResolver.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.sundr.maven;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import io.sundr.maven.filter.Filters;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Exclusion;
+import org.apache.maven.plugin.logging.Log;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
+import org.eclipse.aether.resolution.ArtifactRequest;
+
+/**
+ * Resolves external BOMs and provides its managed dependencies.
+ * Using Aether to get full information about the managed dependencies.
+ */
+public class ExternalBomResolver {
+
+    private MavenSession mavenSession;
+
+    private ArtifactHandler artifactHandler;
+
+    private RepositorySystem system;
+
+    private RepositorySystemSession session;
+
+    private List<RemoteRepository> remoteRepositories;
+
+    private Log logger;
+
+    public ExternalBomResolver(MavenSession mavenSession, ArtifactHandler artifactHandler, RepositorySystem system, RepositorySystemSession session, List<RemoteRepository> remoteRepositories, Log
+            logger) {
+        this.mavenSession = mavenSession;
+        this.artifactHandler = artifactHandler;
+        this.system = system;
+        this.session = session;
+        this.remoteRepositories = remoteRepositories;
+        this.logger = logger;
+    }
+
+    public Map<Artifact, Dependency> resolve(BomConfig config) throws Exception {
+        Map<Artifact, Dependency> dependencies = new LinkedHashMap<Artifact, Dependency>();
+        if (config != null && config.getImports() != null) {
+            for (BomImport bom : config.getImports()) {
+                Map<Artifact, Dependency> deps = resolve(bom);
+                for (Map.Entry<Artifact, Dependency> e : deps.entrySet()) {
+                    if (!dependencies.containsKey(e.getKey())) {
+                        // order is important for imported boms
+                        dependencies.put(e.getKey(), e.getValue());
+                    }
+                }
+            }
+        }
+        return dependencies;
+    }
+
+    private Map<Artifact, Dependency> resolve(BomImport bom) throws Exception {
+        logger.info("Resolving " + bom + " to get managed dependencies ");
+
+        Map<Artifact, Dependency> dependencies = resolveDependencies(bom);
+        Map<Artifact, Dependency> filteredDependencies = Filters.filter(dependencies, Filters.createDependencyManagementFilter(mavenSession, bom));
+
+        int included = filteredDependencies.size();
+        int total = dependencies.size();
+        logger.info("Included " + included + "/" + total + " dependencies from BOM " + bom);
+        return filteredDependencies;
+    }
+
+    private Map<Artifact, Dependency> resolveDependencies(BomImport bom) throws Exception {
+        org.eclipse.aether.artifact.Artifact artifact = new org.eclipse.aether.artifact.DefaultArtifact(bom.getGroupId(), bom.getArtifactId(), "pom", bom.getVersion());
+
+        ArtifactRequest artifactRequest = new ArtifactRequest(artifact, remoteRepositories, null);
+        system.resolveArtifact(session, artifactRequest); // To get an error when the artifact does not exist
+
+        ArtifactDescriptorRequest req = new ArtifactDescriptorRequest(artifact, remoteRepositories, null);
+        ArtifactDescriptorResult res = system.readArtifactDescriptor(session, req);
+
+        Map<Artifact, Dependency> mavenDependencies = new LinkedHashMap<Artifact, Dependency>();
+        if (res.getManagedDependencies() != null) {
+            for (org.eclipse.aether.graph.Dependency dep : res.getManagedDependencies()) {
+                mavenDependencies.put(toMavenArtifact(dep), toMavenDependency(dep));
+            }
+        }
+
+        return mavenDependencies;
+    }
+
+    private Dependency toMavenDependency(org.eclipse.aether.graph.Dependency from) {
+        org.eclipse.aether.artifact.Artifact fromArt = from.getArtifact();
+
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(fromArt.getGroupId());
+        dependency.setArtifactId(fromArt.getArtifactId());
+        dependency.setVersion(fromArt.getVersion());
+        dependency.setType(fromArt.getExtension());
+        dependency.setScope(Artifact.SCOPE_COMPILE.equals(from.getScope()) ? null : from.getScope());
+        dependency.setClassifier(fromArt.getClassifier());
+        dependency.setOptional(dependency.isOptional());
+
+        if (from.getExclusions() != null && from.getExclusions().size() > 0) {
+            List<Exclusion> exclusions = new LinkedList<Exclusion>();
+            for (org.eclipse.aether.graph.Exclusion fromEx : from.getExclusions()) {
+                Exclusion ex = new Exclusion();
+                ex.setGroupId(fromEx.getGroupId());
+                ex.setArtifactId(fromEx.getArtifactId());
+                exclusions.add(ex);
+            }
+            dependency.setExclusions(exclusions);
+        }
+
+        return dependency;
+    }
+
+
+    private Artifact toMavenArtifact(org.eclipse.aether.graph.Dependency dependency) {
+        org.eclipse.aether.artifact.Artifact sa = dependency.getArtifact();
+        Artifact a = new DefaultArtifact(sa.getGroupId(), sa.getArtifactId(), sa.getVersion(), dependency.getScope(), sa.getExtension(), sa.getClassifier(), artifactHandler);
+        return a;
+    }
+
+}

--- a/maven-plugin/src/main/java/io/sundr/maven/ExternalBomResolver.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/ExternalBomResolver.java
@@ -102,10 +102,18 @@ public class ExternalBomResolver {
     private Map<Artifact, Dependency> resolveDependencies(BomImport bom) throws Exception {
         org.eclipse.aether.artifact.Artifact artifact = new org.eclipse.aether.artifact.DefaultArtifact(bom.getGroupId(), bom.getArtifactId(), "pom", bom.getVersion());
 
-        ArtifactRequest artifactRequest = new ArtifactRequest(artifact, remoteRepositories, null);
+        List<RemoteRepository> repositories = remoteRepositories;
+        if (bom.getRepository() != null) {
+            // Include the additional repository into the copy
+            repositories = new LinkedList<RemoteRepository>(repositories);
+            RemoteRepository repo = new RemoteRepository.Builder(bom.getArtifactId() + "-repository", "default", bom.getRepository()).build();
+            repositories.add(0, repo);
+        }
+
+        ArtifactRequest artifactRequest = new ArtifactRequest(artifact, repositories, null);
         system.resolveArtifact(session, artifactRequest); // To get an error when the artifact does not exist
 
-        ArtifactDescriptorRequest req = new ArtifactDescriptorRequest(artifact, remoteRepositories, null);
+        ArtifactDescriptorRequest req = new ArtifactDescriptorRequest(artifact, repositories, null);
         ArtifactDescriptorResult res = system.readArtifactDescriptor(session, req);
 
         Map<Artifact, Dependency> mavenDependencies = new LinkedHashMap<Artifact, Dependency>();

--- a/maven-plugin/src/main/java/io/sundr/maven/GenerateBomMojo.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/GenerateBomMojo.java
@@ -164,6 +164,7 @@ public class GenerateBomMojo extends AbstractSundrioMojo {
         try {
             writer = new FileWriter(generatedBom);
             // Imported dependencies may have important additional information (eg. exclusions)
+            // Taking both the artifacts and their related dependencies
             Map<Artifact, Dependency> dependencies = new LinkedHashMap<Artifact, Dependency>();
             Set<Artifact> plugins = new LinkedHashSet<Artifact>();
 

--- a/maven-plugin/src/main/resources/templates/bom.xml.vm
+++ b/maven-plugin/src/main/resources/templates/bom.xml.vm
@@ -67,7 +67,16 @@
 
                 <type>${d.type}</type>#end#if( $d.classifier && $!d.classifier != '' )
 
-                <classifier>${d.classifier}</classifier>#end
+                <classifier>${d.classifier}</classifier>#end#if( $d.exclusions && $d.exclusions.size() > 0 )
+
+                <exclusions>#foreach( $e in $d.exclusions )
+
+                    <exclusion>
+                        <groupId>${e.groupId}</groupId>
+                        <artifactId>${e.artifactId}</artifactId>
+                    </exclusion>#end
+
+                </exclusions>#end
 
             </dependency>#end
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <maven.version>3.3.1</maven.version>
         <maven.invoker.version>2.0.11</maven.invoker.version>
         <maven.plugin.annotations.version>3.2</maven.plugin.annotations.version>
+        <maven-plugin-plugin-version>3.5</maven-plugin-plugin-version>
         <sun.tools.version>1.7</sun.tools.version>
         <validation.api.version>1.1.0.Final</validation.api.version>
         <velocity.version>1.7</velocity.version>


### PR DESCRIPTION
I added the support for importing external BOMs directly in the main mojo. I added a `imports` child into the configuration, so that a BOM can be composed of direct dependencies of the children modules plus external managed dependencies.

I also added a check to verify if the dependencies of the generated BOMs have conflicts, i.e. same library with different version (this is the case for some BOMs generated in fabric8, where eg. there are 3-4 different versions of `plexus-utils` in the same BOM, the first one wins).
By default a warning is printed to the log, but a flag can turn this to a build failure.

I added support for exclusions in dependency management, because external BOMs usually force you to exclude some transitive dependencies when using a managed lib (eg. with spring-boot managed dependencies you need to exclude all transitive logging dependencies, to prevent conflicts with the embedded slf4j logging mechanism).