### PR TITLE
Allow overriding the version of specific artifacts in the generated BOM

### DIFF
--- a/maven-plugin/src/it/multimodule/pom.xml
+++ b/maven-plugin/src/it/multimodule/pom.xml
@@ -218,6 +218,50 @@
                                 </excludes>
                             </goals>
                         </bom>
+                        <bom>
+                            <artifactId>bom-test-9</artifactId>
+                            <name>Test Project :: Bom 9</name>
+                            <modules>
+                                <excludes>
+                                    <exclude>*:*</exclude>
+                                </excludes>
+                            </modules>
+                            <dependencies>
+                                <includes>
+                                    <include>io.sundr:*</include>
+                                </includes>
+                            </dependencies>
+                            <imports>
+                                <import>
+                                    <groupId>org.springframework.boot</groupId>
+                                    <artifactId>spring-boot-dependencies</artifactId>
+                                    <version>1.4.2.RELEASE</version>
+                                    <dependencyManagement>
+                                        <includes>
+                                            <include>*:*</include>
+                                        </includes>
+                                        <excludes>
+                                            <exclude>com.google.code.gson:gson</exclude>
+                                        </excludes>
+                                    </dependencyManagement>
+                                </import>
+                            </imports>
+                            <overrides>
+                                <override>
+                                    <dependencies>
+                                        <includes>
+                                            <include>org.apache.activemq:*</include>
+                                        </includes>
+                                    </dependencies>
+                                    <version>5.2.0</version>
+                                </override>
+                            </overrides>
+                            <goals>
+                                <excludes>
+                                    <exclude>deploy</exclude>
+                                </excludes>
+                            </goals>
+                        </bom>
                     </boms>
                 </configuration>
                 <executions>

--- a/maven-plugin/src/it/multimodule/verify.bsh
+++ b/maven-plugin/src/it/multimodule/verify.bsh
@@ -27,6 +27,16 @@ Set findDependencies ( String artifactId ) {
     return result;
 }
 
+Map findDependencyVersions ( String artifactId ) {
+    Map result = new HashMap();
+    MavenProject project = readProject(artifactId);
+    for(Dependency dep : project.getDependencyManagement().getDependencies()) {
+        result.put(dep.getGroupId() + ":" + dep.getArtifactId(), dep.getVersion());
+    }
+
+    return result;
+}
+
 boolean isDeployed(String artifactId ) {
     File deployedBomDir = new File( basedir, "../../repository/test/" + artifactId );
     return deployedBomDir.exists();
@@ -46,6 +56,7 @@ boolean deployed5 = isDeployed("bom-test-5");
 boolean deployed6 = isDeployed("bom-test-6");
 boolean deployed7 = isDeployed("bom-test-7");
 boolean deployed8 = isDeployed("bom-test-8");
+boolean deployed9 = isDeployed("bom-test-9");
 
 boolean parent1 = hasParent("bom-test-1");
 boolean parent2 = hasParent("bom-test-2");
@@ -55,6 +66,7 @@ boolean parent5 = hasParent("bom-test-5");
 boolean parent6 = hasParent("bom-test-6");
 boolean parent7 = hasParent("bom-test-7");
 boolean parent8 = hasParent("bom-test-8");
+boolean parent9 = hasParent("bom-test-9");
 
 Set deps1 = findDependencies("bom-test-1");
 Set deps2 = findDependencies("bom-test-2");
@@ -64,6 +76,9 @@ Set deps5 = findDependencies("bom-test-5");
 Set deps6 = findDependencies("bom-test-6");
 Set deps7 = findDependencies("bom-test-7");
 Set deps8 = findDependencies("bom-test-8");
+Set deps9 = findDependencies("bom-test-9");
+
+Map deps9version = findDependencyVersions("bom-test-9");
 
 
 return deployed1 && !parent1 && deps1.size() == 1 && deps1.contains("test:module1") &&
@@ -73,4 +88,5 @@ return deployed1 && !parent1 && deps1.size() == 1 && deps1.contains("test:module
       !deployed5 && !parent5 && deps5.size() == 2 && deps5.contains("test:module2") && deps5.contains("test:module1") &&
       !deployed6 && !parent6 && deps6.size() == 3 && deps6.contains("test:module2") && deps6.contains("test:module1") && deps6.contains("io.sundr:sundr-core") &&
       !deployed7 && !parent7 && deps7.size() > 800 && deps7.contains("org.springframework.boot:spring-boot-starter") && deps7.contains("org.apache.camel:camel-http") && deps7.contains("com.google.code.gson:gson") && deps7.contains("io.sundr:sundr-core") &&
-      !deployed8 && !parent8 && deps8.size() < 800 && deps8.contains("org.springframework.boot:spring-boot-starter") && deps8.contains("org.apache.camel:camel-cxf") && !deps8.contains("org.apache.camel:camel-http") && !deps8.contains("com.google.code.gson:gson") && deps8.contains("io.sundr:sundr-core");
+      !deployed8 && !parent8 && deps8.size() < 800 && deps8.contains("org.springframework.boot:spring-boot-starter") && deps8.contains("org.apache.camel:camel-cxf") && !deps8.contains("org.apache.camel:camel-http") && !deps8.contains("com.google.code.gson:gson") && deps8.contains("io.sundr:sundr-core") &&
+      !deployed9 && !parent9 && deps9.contains("org.springframework.boot:spring-boot-starter") && !deps9.contains("org.apache.camel:camel-http") && !deps9.contains("com.google.code.gson:gson") && deps9.contains("io.sundr:sundr-core") && deps9version.containsKey("org.apache.activemq:activemq-amqp") && deps9version.get("org.apache.activemq:activemq-amqp").equals("5.2.0") && deps9version.containsKey("org.springframework.boot:spring-boot-autoconfigure") && !deps9version.get("org.springframework.boot:spring-boot-autoconfigure").equals("5.2.0");

--- a/maven-plugin/src/main/java/io/sundr/maven/BomConfig.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/BomConfig.java
@@ -29,6 +29,7 @@ public class BomConfig {
     private ArtifactSet dependencies = new ArtifactSet();
     private ArtifactSet plugins = new ArtifactSet();
     private List<BomImport> imports = new LinkedList<BomImport>();
+    private List<VersionOverride> overrides = new LinkedList<VersionOverride>();
     private GoalSet goals = new GoalSet();
     private boolean ignoreScope = true;
     private boolean excludeOptional = true;
@@ -75,6 +76,10 @@ public class BomConfig {
 
     public List<BomImport> getImports() {
         return imports;
+    }
+
+    public List<VersionOverride> getOverrides() {
+        return overrides;
     }
 
     public GoalSet getGoals() {

--- a/maven-plugin/src/main/java/io/sundr/maven/VersionOverride.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/VersionOverride.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.sundr.maven;
+
+/**
+ * Information about version that should be overridden in the final BOM.
+ */
+public class VersionOverride {
+
+    private ArtifactSet dependencies = new ArtifactSet();
+
+    private String version;
+
+    public VersionOverride() {
+    }
+
+    public ArtifactSet getDependencies() {
+        return dependencies;
+    }
+
+    public void setDependencies(ArtifactSet dependencies) {
+        this.dependencies = dependencies;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("VersionOverride{");
+        sb.append("dependencies=").append(dependencies);
+        sb.append(", version='").append(version).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
This allows forcing the version of specific dependencies in a BOM when the one shipped with eg. an external BOM is not good anymore. This is useful in the cases where the external BOM cannot be changed, probably because it belongs to others..

@jamesnetherton maybe you want to check if this is useful for our needs (eg. for case of slf4j).