### PR TITLE
fix: find the right setter for properties with symbols

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
@@ -19,6 +19,7 @@ package io.sundr.builder.internal.functions;
 import io.sundr.Function;
 import io.sundr.FunctionFactory;
 import io.sundr.Provider;
+import io.sundr.SundrException;
 import io.sundr.builder.Constants;
 import io.sundr.builder.TypedVisitor;
 import io.sundr.builder.annotations.Buildable;
@@ -842,11 +843,16 @@ public class ClazzAs {
             }
 
             for (Property property : c.getProperties()) {
-                if (!hasBuildableConstructorWithArgument(c, property) && Setter.has(c, property)) {
-                    String setterName = "set" + property.getNameCapitalized();
+                Method setter;
+                try {
+                    setter = Setter.find(clazz, property);
+                } catch (SundrException e) {
+                    continue; // no setter found nothing to set
+                }
+                if (!hasBuildableConstructorWithArgument(c, property)) {
                     String getterName = Getter.name(property);
                     statements.add(new StringStatement(new StringBuilder()
-                            .append("buildable.").append(setterName).append("(fluent.").append(getterName).append("());")
+                            .append("buildable.").append(setter.getName()).append("(fluent.").append(getterName).append("());")
                             .toString()));
 
                 }


### PR DESCRIPTION
... and support setters in parent classes when generating Builders.

Fixes #125. I did some digging and I don't think this needs to be configurable or that it will break anything. The generated `Builder` constructor was already doing the right thing, searching for the correct `getter` name in the target class (and its parents). We just need the same logic when generating the `build()` method.

E.g. with:

```java
public class Sample {
    private String $ref;
    public void set$Ref(String $ref) { this.$ref = $ref };
}
```

Snipped of generated `Builder` code without changes in this PR:

```java
    public SampleBuilder(SampleFluent<?> fluent,Sample instance,Boolean validationEnabled){
            this.fluent = fluent; 
            fluent.withRef(instance.get$Ref());
            // ...
    }

    public Sample build(){
            Sample buildable = new Sample();
            buildable.setRef(fluent.getRef()); // <-- does not compile!
    }
```

After this PR is applied:

```java
    public SampleBuilder(SampleFluent<?> fluent,Sample instance,Boolean validationEnabled){
            this.fluent = fluent; 
            fluent.withRef(instance.get$Ref());
            // ...
    }

    public Sample build(){
            Sample buildable = new Sample();
            buildable.set$Ref(fluent.getRef());
    }
```