### PR TITLE
#160 refactor: Memory efficient ClassRef instances (reuse)

### DIFF
--- a/codegen/src/main/java/io/sundr/codegen/model/AnnotationRefFluentImpl.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/AnnotationRefFluentImpl.java
@@ -18,23 +18,23 @@ package io.sundr.codegen.model;
 
 import io.sundr.builder.Nested;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
 public class AnnotationRefFluentImpl<A extends AnnotationRefFluent<A>> extends AttributeSupportFluentImpl<A> implements AnnotationRefFluent<A>{
 
     private ClassRefBuilder classRef;
-    private Map<String,Object> parameters = new LinkedHashMap<String,Object>();
+    private final Map<String, Object> parameters = new HashMap<>();
 
     public AnnotationRefFluentImpl(){
     }
     public AnnotationRefFluentImpl(AnnotationRef instance){
-            this.withClassRef(instance.getClassRef()); 
-            this.withParameters(instance.getParameters()); 
-            this.withAttributes(instance.getAttributes()); 
+            this.withClassRef(instance.getClassRef());
+            this.withParameters(instance.getParameters());
+            this.withAttributes(instance.getAttributes());
     }
 
-    
+
 /**
  * This method has been deprecated, please use method buildClassRef instead.
  * @return The buildable object.
@@ -77,23 +77,22 @@ public class AnnotationRefFluentImpl<A extends AnnotationRefFluent<A>> extends A
     }
 
     public A addToParameters(String key,Object value){
-            if(this.parameters == null && key != null && value != null) { this.parameters = new LinkedHashMap<String,Object>(); }
             if(key != null && value != null) {this.parameters.put(key, value);} return (A)this;
     }
 
     public A addToParameters(Map<String,Object> map){
-            if(this.parameters == null && map != null) { this.parameters = new LinkedHashMap<String,Object>(); }
             if(map != null) { this.parameters.putAll(map);} return (A)this;
     }
 
     public A removeFromParameters(String key){
-            if(this.parameters == null) { return (A) this; }
             if(key != null && this.parameters != null) {this.parameters.remove(key);} return (A)this;
     }
 
-    public A removeFromParameters(Map<String,Object> map){
-            if(this.parameters == null) { return (A) this; }
-            if(map != null) { for(Object key : map.keySet()) {if (this.parameters != null){this.parameters.remove(key);}}} return (A)this;
+    public A removeFromParameters(Map<String, Object> map){
+        if (map != null) {
+            map.keySet().forEach(parameters::remove);
+        }
+        return (A) this;
     }
 
     public Map<String,Object> getParameters(){
@@ -101,11 +100,13 @@ public class AnnotationRefFluentImpl<A extends AnnotationRefFluent<A>> extends A
     }
 
     public A withParameters(Map<String,Object> parameters){
-            if (parameters == null) { this.parameters =  new LinkedHashMap<String,Object>();} else {this.parameters = new LinkedHashMap<String,Object>(parameters);} return (A) this;
+        this.parameters.clear();
+        this.parameters.putAll(parameters);
+        return (A) this;
     }
 
     public Boolean hasParameters(){
-            return this.parameters != null;
+            return !this.parameters.isEmpty();
     }
 
     public boolean equals(Object o){
@@ -122,14 +123,14 @@ public class AnnotationRefFluentImpl<A extends AnnotationRefFluent<A>> extends A
     public class ClassRefNestedImpl<N> extends ClassRefFluentImpl<AnnotationRefFluent.ClassRefNested<N>> implements AnnotationRefFluent.ClassRefNested<N>,Nested<N>{
 
             private final ClassRefBuilder builder;
-    
+
             ClassRefNestedImpl(ClassRef item){
                     this.builder = new ClassRefBuilder(this, item);
             }
             ClassRefNestedImpl(){
                     this.builder = new ClassRefBuilder(this);
             }
-    
+
     public N and(){
             return (N) AnnotationRefFluentImpl.this.withClassRef(builder.build());
     }

--- a/codegen/src/main/java/io/sundr/codegen/model/AttributeSupportFluentImpl.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/AttributeSupportFluentImpl.java
@@ -18,49 +18,51 @@ package io.sundr.codegen.model;
 
 import io.sundr.builder.BaseFluent;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
 public class AttributeSupportFluentImpl<A extends AttributeSupportFluent<A>> extends BaseFluent<A> implements AttributeSupportFluent<A>{
 
-    private Map<AttributeKey,Object> attributes = new LinkedHashMap<AttributeKey,Object>();
+    private final Map<AttributeKey, Object> attributes = new HashMap<>(0);
 
     public AttributeSupportFluentImpl(){
     }
+
     public AttributeSupportFluentImpl(AttributeSupport instance){
-            this.withAttributes(instance.getAttributes()); 
+        this.withAttributes(instance.getAttributes());
     }
 
-    public A addToAttributes(AttributeKey key,Object value){
-            if(this.attributes == null && key != null && value != null) { this.attributes = new LinkedHashMap<AttributeKey,Object>(); }
-            if(key != null && value != null) {this.attributes.put(key, value);} return (A)this;
+    public A addToAttributes(AttributeKey key, Object value){
+        if(key != null && value != null) {this.attributes.put(key, value);} return (A)this;
     }
 
-    public A addToAttributes(Map<AttributeKey,Object> map){
-            if(this.attributes == null && map != null) { this.attributes = new LinkedHashMap<AttributeKey,Object>(); }
-            if(map != null) { this.attributes.putAll(map);} return (A)this;
+    public A addToAttributes(Map<AttributeKey, Object> map){
+        if(map != null) { this.attributes.putAll(map);} return (A)this;
     }
 
     public A removeFromAttributes(AttributeKey key){
-            if(this.attributes == null) { return (A) this; }
-            if(key != null && this.attributes != null) {this.attributes.remove(key);} return (A)this;
+        if(key != null) {this.attributes.remove(key);} return (A)this;
     }
 
-    public A removeFromAttributes(Map<AttributeKey,Object> map){
-            if(this.attributes == null) { return (A) this; }
-            if(map != null) { for(Object key : map.keySet()) {if (this.attributes != null){this.attributes.remove(key);}}} return (A)this;
+    public A removeFromAttributes(Map<AttributeKey, Object> map) {
+        if (map != null) {
+            map.keySet().forEach(attributes::remove);
+        }
+        return (A) this;
     }
 
     public Map<AttributeKey,Object> getAttributes(){
-            return this.attributes;
+        return this.attributes;
     }
 
-    public A withAttributes(Map<AttributeKey,Object> attributes){
-            if (attributes == null) { this.attributes =  new LinkedHashMap<AttributeKey,Object>();} else {this.attributes = new LinkedHashMap<AttributeKey,Object>(attributes);} return (A) this;
+    public A withAttributes(Map<AttributeKey,Object> attributes) {
+        this.attributes.clear();
+        this.attributes.putAll(attributes);
+        return (A) this;
     }
 
     public Boolean hasAttributes(){
-            return this.attributes != null;
+            return !this.attributes.isEmpty();
     }
 
     public boolean equals(Object o){

--- a/codegen/src/main/java/io/sundr/codegen/model/ClassRefBuilder.java
+++ b/codegen/src/main/java/io/sundr/codegen/model/ClassRefBuilder.java
@@ -18,7 +18,55 @@ package io.sundr.codegen.model;
 
 import io.sundr.builder.VisitableBuilder;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+
+import static io.sundr.codegen.model.Kind.CLASS;
+import static io.sundr.codegen.model.Kind.ENUM;
+import static io.sundr.codegen.model.Kind.INTERFACE;
+
 public class ClassRefBuilder extends ClassRefFluentImpl<ClassRefBuilder> implements VisitableBuilder<ClassRef,ClassRefBuilder>{
+
+    private static final Map<CacheKey, EditableClassRef> CACHE = new ConcurrentHashMap<>();
+    private static final class CacheKey {
+        private final String fullyQualifiedName;
+        private final int dimensions;
+        private final int modifiers;
+        private final List<TypeRef> arguments;
+
+        private CacheKey(ClassRefFluent<?> fluent, TypeDef definition) {
+            this.fullyQualifiedName = fluent.getFullyQualifiedName();
+            this.dimensions = fluent.getDimensions();
+            final Optional<TypeDef> optionalTypeDef = Optional.ofNullable(definition);
+            this.modifiers = optionalTypeDef.map(TypeDef::getModifiers).orElse(-1);
+            this.arguments = fluent.buildArguments();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CacheKey cacheKey = (CacheKey) o;
+            return dimensions == cacheKey.dimensions &&
+                modifiers == cacheKey.modifiers &&
+                Objects.equals(fullyQualifiedName, cacheKey.fullyQualifiedName) &&
+                Objects.equals(arguments, cacheKey.arguments);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fullyQualifiedName, dimensions, modifiers, arguments);
+        }
+    }
 
     ClassRefFluent<?> fluent;
     Boolean validationEnabled;
@@ -39,30 +87,61 @@ public class ClassRefBuilder extends ClassRefFluentImpl<ClassRefBuilder> impleme
             this(fluent, instance, true);
     }
     public ClassRefBuilder(ClassRefFluent<?> fluent,ClassRef instance,Boolean validationEnabled){
-            this.fluent = fluent; 
-            fluent.withDefinition(instance.getDefinition()); 
-            fluent.withFullyQualifiedName(instance.getFullyQualifiedName()); 
-            fluent.withDimensions(instance.getDimensions()); 
-            fluent.withArguments(instance.getArguments()); 
-            fluent.withAttributes(instance.getAttributes()); 
-            this.validationEnabled = validationEnabled; 
+            this.fluent = fluent;
+            fluent.withDefinition(instance.getDefinition());
+            fluent.withFullyQualifiedName(instance.getFullyQualifiedName());
+            fluent.withDimensions(instance.getDimensions());
+            fluent.withArguments(instance.getArguments());
+            fluent.withAttributes(instance.getAttributes());
+            this.validationEnabled = validationEnabled;
     }
     public ClassRefBuilder(ClassRef instance){
             this(instance,true);
     }
     public ClassRefBuilder(ClassRef instance,Boolean validationEnabled){
-            this.fluent = this; 
-            this.withDefinition(instance.getDefinition()); 
-            this.withFullyQualifiedName(instance.getFullyQualifiedName()); 
-            this.withDimensions(instance.getDimensions()); 
-            this.withArguments(instance.getArguments()); 
-            this.withAttributes(instance.getAttributes()); 
-            this.validationEnabled = validationEnabled; 
+            this.fluent = this;
+            this.withDefinition(instance.getDefinition());
+            this.withFullyQualifiedName(instance.getFullyQualifiedName());
+            this.withDimensions(instance.getDimensions());
+            this.withArguments(instance.getArguments());
+            this.withAttributes(instance.getAttributes());
+            this.validationEnabled = validationEnabled;
+    }
+
+    private static boolean canCache(List<TypeRef> arguments) {
+        if (arguments.isEmpty()) {
+            return true;
+        }
+        return arguments.stream().noneMatch(
+            ((Predicate<TypeRef>) TypeParamRef.class::isInstance).negate().and(
+                ((Predicate<TypeRef>) WildcardRefBuilder.class::isInstance).negate()).and(
+                ((Predicate<TypeRef>) WildcardRef.class::isInstance).negate()));
+    }
+
+    private static boolean canCache(ClassRefFluent<?> fluent, TypeDef definition) {
+        return definition != null
+            && Arrays.asList(CLASS, INTERFACE, ENUM).contains(definition.getKind())
+            && definition.getParameters().isEmpty()
+            && canCache(fluent.buildArguments());
+    }
+
+    private static EditableClassRef newInstance(ClassRefFluent<?> fluent, TypeDef definition) {
+        return new EditableClassRef(definition, fluent.getFullyQualifiedName(),
+            fluent.getDimensions(), fluent.buildArguments(),fluent.getAttributes());
     }
 
     public EditableClassRef build(){
-            EditableClassRef buildable = new EditableClassRef(fluent.getDefinition(),fluent.getFullyQualifiedName(),fluent.getDimensions(),fluent.getArguments(),fluent.getAttributes());
-            return buildable;
+        final TypeDef definition = fluent.buildDefinition();
+        if (canCache(fluent, definition)) {
+            final CacheKey key = new CacheKey(fluent, definition);
+            // ConcurrentHashMap#computeIfAbsent -> dead-lock
+            return Optional.ofNullable(CACHE.get(key)).orElseGet(() -> {
+                final EditableClassRef ret = newInstance(fluent, definition);
+                CACHE.put(key, ret);
+                return ret;
+            });
+        }
+        return newInstance(fluent, definition);
     }
 
     public boolean equals(Object o){

--- a/codegen/src/main/java/io/sundr/codegen/processor/JavaGeneratingProcessor.java
+++ b/codegen/src/main/java/io/sundr/codegen/processor/JavaGeneratingProcessor.java
@@ -20,16 +20,16 @@ import io.sundr.codegen.functions.Sources;
 import io.sundr.codegen.generator.CodeGeneratorBuilder;
 import io.sundr.codegen.generator.CodeGeneratorContext;
 import io.sundr.codegen.model.TypeDef;
-
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.FilerException;
 import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.regex.Pattern;
+import java.io.Writer;
 
 public abstract class JavaGeneratingProcessor extends AbstractProcessor {
 
@@ -67,13 +67,15 @@ public abstract class JavaGeneratingProcessor extends AbstractProcessor {
             return;
         }
         System.err.println("Generating: "+model.getFullyQualifiedName());
-        new CodeGeneratorBuilder<TypeDef>()
+        try (Writer writer = fileObject.openWriter()) {
+            new CodeGeneratorBuilder<TypeDef>()
                 .withContext(context)
                 .withModel(model)
-                .withWriter(fileObject.openWriter())
+                .withWriter(writer)
                 .withTemplateResource(resourceName)
                 .build()
                 .generate();
+        }
     }
 
     /**
@@ -118,14 +120,16 @@ public abstract class JavaGeneratingProcessor extends AbstractProcessor {
             }
         }
         System.err.println("Generating: "+fileObject.getName());
-        new CodeGeneratorBuilder<T>()
+        try (Writer writer = fileObject.openWriter()) {
+            new CodeGeneratorBuilder<T>()
                 .withContext(context)
                 .withModel(model)
                 .withParameters(parameters)
-                .withWriter(fileObject.openWriter())
+                .withWriter(writer)
                 .withTemplateContent(content)
                 .build()
                 .generate();
+        }
     }
 
     /**
@@ -162,7 +166,7 @@ public abstract class JavaGeneratingProcessor extends AbstractProcessor {
     }
 
     /**
-     * Generate a {@link TypeDef} from the specified model, parameters and template. 
+     * Generate a {@link TypeDef} from the specified model, parameters and template.
      */
     public <T> TypeDef createTypeFromTemplate(T model, String[] parameters, String content) {
         try (StringWriter writer = new StringWriter()) {

--- a/core/src/main/java/io/sundr/Function.java
+++ b/core/src/main/java/io/sundr/Function.java
@@ -16,6 +16,7 @@
 
 package io.sundr;
 
+@FunctionalInterface
 public interface Function<Y, X> {
 
     X apply(Y item);


### PR DESCRIPTION
Optimizes codegen memory usage.

Use `HashMap` (less memory footprint) instead of `LinkedHashMap` where applicable.

Cache `EditableClassRef` [instances](https://en.wikipedia.org/wiki/Flyweight_pattern).

HeapDump analysis of Kubernetes-client compilation shows an enormous amount of `EditableClassRef` instances being generated:
![201912171040NOOptimizations](https://user-images.githubusercontent.com/488391/71172033-806bb000-225f-11ea-80d1-cdf521743aba.png)

Same HeapDump after refactor implementation cuts in half the number of EditableClassRef, considerably reducing the amount of memory consumed by the process:
![201912191252-ClassRefCache](https://user-images.githubusercontent.com/488391/71172103-aee98b00-225f-11ea-8bac-c3d884c3d590.png)


Improves: #160 

