### PR TITLE
Add supported source annotation

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/processor/BuildableProcessor.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/processor/BuildableProcessor.java
@@ -22,6 +22,8 @@ import java.util.Set;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
@@ -44,6 +46,7 @@ import static io.sundr.builder.Constants.LAZY_COLLECTIONS_INIT_ENABLED;
 import static io.sundr.builder.Constants.LAZY_MAP_INIT_ENABLED;
 import static io.sundr.builder.Constants.VALIDATION_ENABLED;
 
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes("io.sundr.builder.annotations.Buildable")
 public class BuildableProcessor extends AbstractBuilderProcessor {
     @Override

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/processor/ExternalBuildableProcessor.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/processor/ExternalBuildableProcessor.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -47,6 +49,7 @@ import static io.sundr.builder.Constants.LAZY_COLLECTIONS_INIT_ENABLED;
 import static io.sundr.builder.Constants.LAZY_MAP_INIT_ENABLED;
 import static io.sundr.builder.Constants.VALIDATION_ENABLED;
 
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes("io.sundr.builder.annotations.ExternalBuildables")
 public class ExternalBuildableProcessor extends AbstractBuilderProcessor {
     @Override

--- a/annotations/resourcecify/src/main/java/io/sundr/resourcecify/internal/processor/ResourcecifyProcessor.java
+++ b/annotations/resourcecify/src/main/java/io/sundr/resourcecify/internal/processor/ResourcecifyProcessor.java
@@ -28,6 +28,8 @@ import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -37,7 +39,7 @@ import javax.tools.StandardLocation;
 
 import io.sundr.resourcecify.annotations.Resourcecify;
 
-
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes("io.sundr.resourcecify.annotations.Resourcecify")
 public class ResourcecifyProcessor extends AbstractProcessor {
 

--- a/annotations/transform/src/main/java/io/sundr/transform/internal/VelocityTransformationProcessor.java
+++ b/annotations/transform/src/main/java/io/sundr/transform/internal/VelocityTransformationProcessor.java
@@ -32,6 +32,8 @@ import io.sundr.transform.annotations.VelocityTransformations;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -55,6 +57,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes( { "io.sundr.transform.annotations.VelocityTransformation", "io.sundr.transform.annotations.VelocityTransformations" } )
 public class VelocityTransformationProcessor extends JavaGeneratingProcessor {
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,9 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <compilerArgs>
+                        <arg>-Werror</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

I have seen many times people having an issue with 
```
COMPILE> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project kubernetes-model-core: Compilation failure: Compilation failure: 
COMPILE> [ERROR] No SupportedSourceVersion annotation found on io.sundr.builder.internal.processor.BuildableProcessor, returning RELEASE_6.
COMPILE> [ERROR] Supported source version 'RELEASE_6' from annotation processor 'io.sundr.builder.internal.processor.BuildableProcessor' less than -source '1.8'
COMPILE> [ERROR] No SupportedSourceVersion annotation found on io.sundr.builder.internal.processor.ExternalBuildableProcessor, returning RELEASE_6.
COMPILE> [ERROR] Supported source version 'RELEASE_6' from annotation processor 'io.sundr.builder.internal.processor.ExternalBuildableProcessor' less than -source '1.8'
COMPILE> [ERROR] No SupportedSourceVersion annotation found on io.sundr.resourcecify.internal.processor.ResourcecifyProcessor, returning RELEASE_6.
COMPILE> [ERROR] Supported source version 'RELEASE_6' from annotation processor 'io.sundr.resourcecify.internal.processor.ResourcecifyProcessor' less than -source '1.8'
COMPILE> [ERROR] No SupportedSourceVersion annotation found on io.sundr.transform.internal.VelocityTransformationProcessor, returning RELEASE_6.
COMPILE> [ERROR] Supported source version 'RELEASE_6' from annotation processor 'io.sundr.transform.internal.VelocityTransformationProcessor' less than -source '1.8'
```
This should fix it.