### PR TITLE
Typo

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/BuilderContextManager.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/BuilderContextManager.java
@@ -41,7 +41,7 @@ public class BuilderContextManager {
             if (!packageName.equals(context.getBuilderPackage())) {
                 throw new IllegalStateException("Cannot use different builder package names in a single project. Used:"
                         + packageName + " but package:"
-                        + context.getGenerateBuilderPackage() + " already exists.");
+                        + context.getBuilderPackage() + " already exists.");
             } else if (!generateBuilderPackage.equals(context.getGenerateBuilderPackage())) {
                 throw new IllegalStateException("Cannot use different values for generate builder package in a single project.");
             } else {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

I believe there is a typo in the exception. See the message below.
```
java.lang.IllegalStateException: Cannot use different builder package names in a single project. Used:io.fabric8.kubernetes.api.builder but package:false already exists.
```
It prints `false` instead of the package name.