### PR TITLE
Reduce output verbosity by reusing the progress line

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/processor/AbstractBuilderProcessor.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/processor/AbstractBuilderProcessor.java
@@ -225,7 +225,7 @@ public abstract class AbstractBuilderProcessor extends JavaGeneratingProcessor {
 
   /**
    * Create a mapping from class name to {@link ClassRef}.
-   * 
+   *
    * @param builderContext The builder context.
    */
   public void addCustomMappings(BuilderContext builderContext) {
@@ -281,8 +281,8 @@ public abstract class AbstractBuilderProcessor extends JavaGeneratingProcessor {
     int count = 0;
     for (TypeDef typeDef : buildables) {
       try {
-        double percentage = 100 * (count++) / total;
-        System.err.println(Math.round(percentage) + "%: " + typeDef.getFullyQualifiedName());
+        double percentage = 100d * (count++) / total;
+        System.err.printf("\033[2K%3d%% Generating: %s\r", Math.round(percentage), typeDef.getFullyQualifiedName());
 
         generateFromResources(ClazzAs.FLUENT_INTERFACE.apply(typeDef),
             Constants.DEFAULT_SOURCEFILE_TEMPLATE_LOCATION);
@@ -330,7 +330,7 @@ public abstract class AbstractBuilderProcessor extends JavaGeneratingProcessor {
 
   /**
    * Returns true if pojos where generated.
-   * 
+   *
    * @param builderContext The builder context.
    * @param buildables The set of buildables.
    */

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/processor/BuildableProcessor.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/processor/BuildableProcessor.java
@@ -34,6 +34,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
 
 import io.sundr.builder.Visitor;
 import io.sundr.builder.annotations.Buildable;
@@ -113,7 +114,8 @@ public class BuildableProcessor extends AbstractBuilderProcessor {
     ctx.getDefinitionRepository().updateReferenceMap();
     generateBuildables(ctx, buildables);
     generatePojos(ctx, buildables);
-    System.err.println("100%: Builder generation complete.");
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE,
+        String.format("%-120s", "100%: Builder generation complete."));
     return false;
   }
 }

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/processor/ExternalBuildableProcessor.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/processor/ExternalBuildableProcessor.java
@@ -40,6 +40,7 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
 
 import io.sundr.builder.Visitor;
 import io.sundr.builder.annotations.ExternalBuildables;
@@ -180,7 +181,8 @@ public class ExternalBuildableProcessor extends AbstractBuilderProcessor {
     ctx.getDefinitionRepository().updateReferenceMap();
     generateBuildables(ctx, buildables);
     generatePojos(ctx, buildables);
-    System.err.println("100%: Builder generation complete.");
+    processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE,
+        String.format("%-120s", "100%: Builder generation complete."));
     return true;
   }
 


### PR DESCRIPTION
The output when generating a large model can be annoying, this PR tries to reduce the verbosity and at the same time do some formatting of the output by reusing the lines.

Some "Generating:" lines make the output unnecessary verbose so they are commented, the only lines that are keep printed in a new line are the "Skipping:" (although they might be unnecessary too).