### PR TITLE
fix: properties should have their associated annotation parameters

### DIFF
--- a/codegen/src/main/java/io/sundr/codegen/functions/ClassTo.java
+++ b/codegen/src/main/java/io/sundr/codegen/functions/ClassTo.java
@@ -261,11 +261,12 @@ public class ClassTo {
       AnnotationRef annotationRef = ANNOTATIONTYPEREF.apply(annotationType);
       Map<String, Object> parameters = new HashMap<>();
       for (java.lang.reflect.Method method : annotationType.getDeclaredMethods()) {
+        final String name = method.getName();
         try {
           final Object value = method.invoke(annotation, (Object[]) null);
-          parameters.put(method.getName(), value);
+          parameters.put(name, value);
         } catch (IllegalAccessException | InvocationTargetException e) {
-          throw new RuntimeException(e);
+          System.out.printf("Couldn't retrieve '%s' parameter value for %s%n", name, annotationType.getName());
         }
       }
       annotationRef = new AnnotationRefBuilder(annotationRef).withParameters(parameters).build();
@@ -310,9 +311,9 @@ public class ClassTo {
       }
 
       methods.add(new MethodBuilder()
-          .withName(method.getName())
-          .withDefaultMethod(method.isDefault())
-          .withModifiers(method.getModifiers())
+              .withName(method.getName())
+              .withDefaultMethod(method.isDefault())
+              .withModifiers(method.getModifiers())
               .withReturnType(TYPEREF.apply(method.getReturnType()))
               .withArguments(arguments)
               .withParameters(parameters)

--- a/codegen/src/main/java/io/sundr/codegen/functions/ClassTo.java
+++ b/codegen/src/main/java/io/sundr/codegen/functions/ClassTo.java
@@ -16,6 +16,11 @@
 
 package io.sundr.codegen.functions;
 
+import io.sundr.FunctionFactory;
+import io.sundr.codegen.DefinitionRepository;
+import io.sundr.codegen.model.Method;
+import io.sundr.codegen.model.*;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.util.*;
@@ -23,11 +28,6 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import io.sundr.FunctionFactory;
-import io.sundr.codegen.DefinitionRepository;
-import io.sundr.codegen.model.*;
-import io.sundr.codegen.model.Method;
 
 public class ClassTo {
 
@@ -121,17 +121,11 @@ public class ClassTo {
   });
 
   public static final Function<Class<? extends Annotation>, AnnotationRef> ANNOTATIONTYPEREF = FunctionFactory
-      .cache(new Function<Class<? extends Annotation>, AnnotationRef>() {
-
-        @Override
-        public AnnotationRef apply(Class<? extends Annotation> item) {
-          //An annotation can't be a primitive or a void type, so its safe to cast.
-          ClassRef classRef = (ClassRef) TYPEREF.apply(item);
-          Map<String, Object> parameters;
-
-          return new AnnotationRefBuilder().withClassRef(classRef).build();
-        }
-      });
+          .cache(item -> {
+            //An annotation can't be a primitive or a void type, so its safe to cast.
+            ClassRef classRef = (ClassRef) TYPEREF.apply(item);
+            return new AnnotationRefBuilder().withClassRef(classRef).build();
+          });
 
   private static final Function<Class, TypeDef> INTERNAL_TYPEDEF = new Function<Class, TypeDef>() {
     public TypeDef apply(Class item) {
@@ -238,9 +232,7 @@ public class ClassTo {
     Set<Property> properties = new HashSet<Property>();
     for (Field field : item.getDeclaredFields()) {
       List<AnnotationRef> annotationRefs = new ArrayList<AnnotationRef>();
-      for (Annotation annotation : field.getDeclaredAnnotations()) {
-        annotationRefs.add(ANNOTATIONTYPEREF.apply(annotation.annotationType()));
-      }
+      processAnnotatedElement(field, annotationRefs);
 
       if (field.getGenericType() instanceof Class) {
         references.add((Class) field.getGenericType());
@@ -254,49 +246,42 @@ public class ClassTo {
             .collect(Collectors.toList()));
       }
       properties.add(new PropertyBuilder()
-          .withName(field.getName())
-          .withModifiers(field.getModifiers())
-          .withAnnotations(annotationRefs)
-          .withTypeRef(TYPEREF.apply(field.getGenericType()))
-          .build());
+              .withName(field.getName())
+              .withModifiers(field.getModifiers())
+              .withAnnotations(annotationRefs)
+              .withTypeRef(TYPEREF.apply(field.getGenericType()))
+              .build());
     }
     return properties;
+  }
+
+  private static void processAnnotatedElement(AnnotatedElement field, List<AnnotationRef> annotationRefs) {
+    for (Annotation annotation : field.getDeclaredAnnotations()) {
+      final Class<? extends Annotation> annotationType = annotation.annotationType();
+      AnnotationRef annotationRef = ANNOTATIONTYPEREF.apply(annotationType);
+      Map<String, Object> parameters = new HashMap<>();
+      for (java.lang.reflect.Method method : annotationType.getDeclaredMethods()) {
+        try {
+          final Object value = method.invoke(annotation, (Object[]) null);
+          parameters.put(method.getName(), value);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      annotationRef = new AnnotationRefBuilder(annotationRef).withParameters(parameters).build();
+
+      annotationRefs.add(annotationRef);
+    }
   }
 
   private static Set<Method> getConstructors(Class item, Set<Class> references) {
     Set<Method> constructors = new HashSet<Method>();
     for (java.lang.reflect.Constructor constructor : item.getDeclaredConstructors()) {
       List<AnnotationRef> annotationRefs = new ArrayList<AnnotationRef>();
-      for (Annotation annotation : constructor.getDeclaredAnnotations()) {
-        annotationRefs.add(ANNOTATIONTYPEREF.apply(annotation.annotationType()));
-      }
-
       List<ClassRef> exceptionRefs = new ArrayList<>();
-      for (Class exceptionType : constructor.getExceptionTypes()) {
-        exceptionRefs.add((ClassRef) TYPEREF.apply(exceptionType));
-      }
-
       List<Property> arguments = new ArrayList<Property>();
-      for (int i = 1; i <= constructor.getGenericParameterTypes().length; i++) {
-        Type argumentType = constructor.getGenericParameterTypes()[i - 1];
-        arguments.add(new PropertyBuilder()
-            .withName(ARGUMENT_PREFIX + i)
-            .withTypeRef(TYPEREF.apply(argumentType))
-            .build());
-
-        if (argumentType instanceof Class) {
-          references.add((Class) argumentType);
-        }
-      }
-
       List<TypeParamDef> parameters = new ArrayList<TypeParamDef>();
-      for (Type type : constructor.getGenericParameterTypes()) {
-
-        TypeParamDef typeParamDef = TYPEPARAMDEF.apply(type);
-        if (typeParamDef != null) {
-          parameters.add(typeParamDef);
-        }
-      }
+      processMethod(references, constructor, annotationRefs, exceptionRefs, arguments, parameters);
 
       constructors.add(new MethodBuilder()
           .withName(constructor.getName())
@@ -314,36 +299,11 @@ public class ClassTo {
     Set<Method> methods = new HashSet<Method>();
     for (java.lang.reflect.Method method : item.getDeclaredMethods()) {
       List<AnnotationRef> annotationRefs = new ArrayList<>();
-      for (Annotation annotation : method.getDeclaredAnnotations()) {
-        annotationRefs.add(ANNOTATIONTYPEREF.apply(annotation.annotationType()));
-      }
-
       List<ClassRef> exceptionRefs = new ArrayList<>();
-      for (Class exceptionType : method.getExceptionTypes()) {
-        exceptionRefs.add((ClassRef) TYPEREF.apply(exceptionType));
-      }
-
       List<Property> arguments = new ArrayList<Property>();
-      for (int i = 1; i <= method.getGenericParameterTypes().length; i++) {
-        Type argumentType = method.getGenericParameterTypes()[i - 1];
-        arguments.add(new PropertyBuilder()
-            .withName(ARGUMENT_PREFIX + i)
-            .withTypeRef(TYPEREF.apply(argumentType))
-            .build());
-
-        if (argumentType instanceof Class) {
-          references.add((Class) argumentType);
-        }
-      }
-
       List<TypeParamDef> parameters = new ArrayList<TypeParamDef>();
-      for (Type type : method.getGenericParameterTypes()) {
+      processMethod(references, method, annotationRefs, exceptionRefs, arguments, parameters);
 
-        TypeParamDef typeParamDef = TYPEPARAMDEF.apply(type);
-        if (typeParamDef != null) {
-          parameters.add(typeParamDef);
-        }
-      }
       Map<AttributeKey, Object> attributes = new HashMap<>();
       if (method.getDefaultValue() != null) {
         attributes.put(Attributeable.DEFAULT_VALUE, method.getDefaultValue());
@@ -353,14 +313,44 @@ public class ClassTo {
           .withName(method.getName())
           .withDefaultMethod(method.isDefault())
           .withModifiers(method.getModifiers())
-          .withReturnType(TYPEREF.apply(method.getReturnType()))
-          .withArguments(arguments)
-          .withParameters(parameters)
-          .withExceptions(exceptionRefs)
-          .withAnnotations(annotationRefs)
-          .withAttributes(attributes)
-          .build());
+              .withReturnType(TYPEREF.apply(method.getReturnType()))
+              .withArguments(arguments)
+              .withParameters(parameters)
+              .withExceptions(exceptionRefs)
+              .withAnnotations(annotationRefs)
+              .withAttributes(attributes)
+              .build());
     }
     return methods;
+  }
+
+  private static void processMethod(Set<Class> references, java.lang.reflect.Executable method,
+                                    List<AnnotationRef> annotationRefs, List<ClassRef> exceptionRefs, List<Property> arguments,
+                                    List<TypeParamDef> parameters) {
+    processAnnotatedElement(method, annotationRefs);
+
+    for (Class exceptionType : method.getExceptionTypes()) {
+      exceptionRefs.add((ClassRef) TYPEREF.apply(exceptionType));
+    }
+
+    for (int i = 1; i <= method.getGenericParameterTypes().length; i++) {
+      Type argumentType = method.getGenericParameterTypes()[i - 1];
+      arguments.add(new PropertyBuilder()
+              .withName(ARGUMENT_PREFIX + i)
+              .withTypeRef(TYPEREF.apply(argumentType))
+              .build());
+
+      if (argumentType instanceof Class) {
+        references.add((Class) argumentType);
+      }
+    }
+
+    for (Type type : method.getGenericParameterTypes()) {
+
+      TypeParamDef typeParamDef = TYPEPARAMDEF.apply(type);
+      if (typeParamDef != null) {
+        parameters.add(typeParamDef);
+      }
+    }
   }
 }

--- a/codegen/src/test/java/io/sundr/codegen/functions/ClassToTypeDefTest.java
+++ b/codegen/src/test/java/io/sundr/codegen/functions/ClassToTypeDefTest.java
@@ -16,23 +16,16 @@
 
 package io.sundr.codegen.functions;
 
-import static org.junit.Assert.*;
+import io.sundr.codegen.model.*;
+import io.sundr.example.*;
+import org.junit.Test;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
-
-import io.sundr.codegen.model.ClassRef;
-import io.sundr.codegen.model.Property;
-import io.sundr.codegen.model.TypeDef;
-import io.sundr.codegen.model.TypeRef;
-import io.sundr.example.Child;
-import io.sundr.example.Interfazz;
-import io.sundr.example.Person;
-import io.sundr.example.Super;
+import static org.junit.Assert.*;
 
 public class ClassToTypeDefTest {
 
@@ -86,11 +79,31 @@ public class ClassToTypeDefTest {
     assertTrue(typeDef.getImplementsList().stream().anyMatch(c -> c.getFullyQualifiedName().equals(Interfazz.class.getName())));
   }
 
+  @Test
+  public void annotationsShouldHaveParameters() {
+    final TypeDef typeDef = ClassTo.TYPEDEF.apply(Other.class);
+    final List<Property> properties = typeDef.getProperties();
+    final Property foo = properties.stream().filter(p -> p.getName().equals("foo")).findFirst()
+            .orElseThrow(RuntimeException::new);
+    List<AnnotationRef> annotations = foo.getAnnotations();
+    assertEquals(1, annotations.size());
+    AnnotationRef annotationRef = annotations.get(0);
+    assertTrue(annotationRef.toString().contains("TestAnnotation"));
+    assertEquals(Other.FOO_NAME, annotationRef.getParameters().get("name"));
+    final Method something = typeDef.getMethods().stream().filter(p -> p.getName().equals("something")).findFirst()
+            .orElseThrow(RuntimeException::new);
+    annotations = something.getAnnotations();
+    assertEquals(1, annotations.size());
+    annotationRef = annotations.get(0);
+    assertEquals(Other.SOMETHING_NAME, annotationRef.getParameters().get("name"));
+    assertArrayEquals(new int[]{1, 2, 3, 5, 7}, (int[]) annotationRef.getParameters().get("values"));
+  }
+
   public static Optional<ClassRef> findClassRef(TypeDef def, String propertyName) {
     return def.getProperties().stream()
-        .filter(p -> propertyName.equals(p.getName()))
-        .filter(p -> p.getTypeRef() instanceof ClassRef)
-        .map(p -> (ClassRef) p.getTypeRef())
-        .findFirst();
+            .filter(p -> propertyName.equals(p.getName()))
+            .filter(p -> p.getTypeRef() instanceof ClassRef)
+            .map(p -> (ClassRef) p.getTypeRef())
+            .findFirst();
   }
 }

--- a/codegen/src/test/java/io/sundr/example/Other.java
+++ b/codegen/src/test/java/io/sundr/example/Other.java
@@ -1,4 +1,13 @@
 package io.sundr.example;
 
 public class Other {
+  public static final String FOO_NAME = "foo";
+  public static final String SOMETHING_NAME = "myName";
+
+  @TestAnnotation(name = FOO_NAME)
+  private String foo;
+
+  @TestAnnotation(name = SOMETHING_NAME, values = {1, 2, 3, 5, 7})
+  private void something() {
+  }
 }

--- a/codegen/src/test/java/io/sundr/example/TestAnnotation.java
+++ b/codegen/src/test/java/io/sundr/example/TestAnnotation.java
@@ -1,0 +1,16 @@
+package io.sundr.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, METHOD})
+@Retention(RUNTIME)
+public @interface TestAnnotation {
+  String name();
+
+  int[] values() default {};
+}


### PR DESCRIPTION
Fixes #214 (sorta). Turns out that annotations are rather painful to
process as you cannot call a method that you got from the annotation
type directly on it, so a proper fix would be to pass the actual
annotation instead of the annotation type so that both are available
during the processing.