### PR TITLE
feat: @ExternalBuildables can now include/exclude abstract classes an…

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/annotations/ExternalBuildables.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/annotations/ExternalBuildables.java
@@ -41,6 +41,10 @@ public @interface ExternalBuildables {
 
   BuildableReference[] refs() default {};
 
+  boolean includeInterfaces() default true;
+
+  boolean includeAbstractClasses() default true;
+
   String[] value() default {};
 
   String[] includes() default {};


### PR DESCRIPTION
This pull request adds more control to the `@ExternalBuildables` annotation.

The intention is to use this annotation going forward in order to generate the model builders, without binding the model objects themselves with the `@Buildable` annotation. While experimenting with this option, I found  out that we did need this option.