### PR TITLE
refactor: ensure build set to list uses a mutable ArrayList

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/BuilderContext.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/BuilderContext.java
@@ -612,7 +612,7 @@ public class BuilderContext {
         .withModifiers(modifiersToInt(Modifier.PUBLIC, Modifier.STATIC))
         .withName("build")
         .withParameters(T)
-        .withReturnType(Collections.LIST.toReference(T.toReference()))
+        .withReturnType(Collections.ARRAY_LIST.toReference(T.toReference()))
         .addNewArgument()
         .withTypeRef(Collections.SET.toReference(new WildcardRefBuilder().withBoundKind(BoundKind.EXTENDS)
             .withBounds(builderInterface
@@ -622,7 +622,7 @@ public class BuilderContext {
         .endArgument()
         .withNewBlock()
         .addNewStringStatementStatement(
-            "return set == null ? null : set.stream().map(Builder::build).collect(Collectors.toList());")
+            "return set == null ? null : new ArrayList<>(set.stream().map(Builder::build).collect(Collectors.toList()));")
         .endBlock()
         .endMethod()
 

--- a/core/src/main/java/io/sundr/builder/BaseFluent.java
+++ b/core/src/main/java/io/sundr/builder/BaseFluent.java
@@ -51,8 +51,8 @@ public class BaseFluent<F extends Fluent<F>> implements Fluent<F>, Visitable<F> 
     return list == null ? null : new ArrayList<T>(list.stream().map(Builder::build).collect(Collectors.toList()));
   }
 
-  public static <T> List<T> build(Set<? extends Builder<? extends T>> set) {
-    return set == null ? null : set.stream().map(Builder::build).collect(Collectors.toList());
+  public static <T> ArrayList<T> build(Set<? extends Builder<? extends T>> set) {
+    return set == null ? null : new ArrayList<T>(set.stream().map(Builder::build).collect(Collectors.toList()));
   }
 
   public static <T> ArrayList<T> aggregate(List<? extends T>... lists) {


### PR DESCRIPTION
This is mostly a cleanup of generated builder types and some minor other improvements