### PR TITLE
feat: provide methods usingValidation/usingValidator on validation enabled builders

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
@@ -365,7 +365,7 @@ public class ClazzAs {
       fields.add(validationEnabledProperty);
 
       Method emptyConstructor = new MethodBuilder().withModifiers(Types.modifiersToInt(Modifier.PUBLIC)).withNewBlock()
-          .addNewStringStatementStatement("this(true);").endBlock().build();
+          .addNewStringStatementStatement("this(false);").endBlock().build();
 
       Method validationEnabledConstructor = new MethodBuilder().withModifiers(Types.modifiersToInt(Modifier.PUBLIC))
           .addNewArgument().withTypeRef(io.sundr.model.utils.Types.BOOLEAN_REF).withName("validationEnabled").and()
@@ -378,7 +378,7 @@ public class ClazzAs {
           })).endBlock().build();
 
       Method fluentConstructor = new MethodBuilder().withModifiers(Types.modifiersToInt(Modifier.PUBLIC)).addNewArgument()
-          .withTypeRef(fluent).withName("fluent").and().withNewBlock().addNewStringStatementStatement("this(fluent, true);")
+          .withTypeRef(fluent).withName("fluent").and().withNewBlock().addNewStringStatementStatement("this(fluent, false);")
           .endBlock().build();
 
       Method fluentAndValidationConstructor = new MethodBuilder().withModifiers(Types.modifiersToInt(Modifier.PUBLIC))
@@ -394,7 +394,7 @@ public class ClazzAs {
 
       Method instanceAndFluentCosntructor = new MethodBuilder().withModifiers(Types.modifiersToInt(Modifier.PUBLIC))
           .addNewArgument().withTypeRef(fluent).withName("fluent").and().addNewArgument().withTypeRef(instanceRef)
-          .withName("instance").and().withNewBlock().addNewStringStatementStatement("this(fluent, instance, true);").endBlock()
+          .withName("instance").and().withNewBlock().addNewStringStatementStatement("this(fluent, instance, false);").endBlock()
           .build();
 
       Method instanceAndFluentAndValidationEnabledCosntructor = new MethodBuilder()
@@ -409,8 +409,7 @@ public class ClazzAs {
 
       Method instanceConstructor = new MethodBuilder().withModifiers(Types.modifiersToInt(Modifier.PUBLIC)).addNewArgument()
           .withTypeRef(instanceRef).withName("instance").and().withNewBlock()
-          .addNewStringStatementStatement("this(instance,true);").endBlock().build();
-
+          .addNewStringStatementStatement("this(instance,false);").endBlock().build();
       Method instanceAndValidationEnabledConstructor = new MethodBuilder()
           .withModifiers(Types.modifiersToInt(Modifier.PUBLIC)).addNewArgument().withTypeRef(instanceRef)
           .withName("instance").and().addNewArgument().withTypeRef(Types.BOOLEAN_REF)
@@ -472,7 +471,7 @@ public class ClazzAs {
               }
             })).endBlock().build();
 
-        Method instanceAndFluentAndValidatorCosntructor = new MethodBuilder()
+        Method instanceAndFluentAndValidatorConstructor = new MethodBuilder()
             .withModifiers(Types.modifiersToInt(Modifier.PUBLIC)).addNewArgument().withTypeRef(fluent).withName("fluent")
             .and().addNewArgument().withTypeRef(instanceRef).withName("instance").and().addNewArgument()
             .withTypeRef(validatorRef).withName("validator").and()
@@ -493,9 +492,43 @@ public class ClazzAs {
             .endBlock()
             .build();
 
+        Method fluentAndValidatorConstructor = new MethodBuilder()
+            .withModifiers(Types.modifiersToInt(Modifier.PUBLIC)).addNewArgument().withTypeRef(fluent).withName("fluent")
+            .and().addNewArgument()
+            .withTypeRef(validatorRef).withName("validator").and()
+            .withNewBlock()
+            .addNewStringStatementStatement("this.fluent = fluent;")
+            .addNewStringStatementStatement("this.validator = validator;")
+            .addNewStringStatementStatement("this.validationEnabled = validator != null; ")
+            .endBlock()
+            .build();
+
+        Method usingValidation = new MethodBuilder().withModifiers(Types.modifiersToInt(Modifier.PUBLIC))
+            .withReturnType(builderType.toInternalReference())
+            .withName("usingValidation")
+            .withNewBlock()
+            .addNewStringStatementStatement("return new " + builderType.getName() + "(this, true);")
+            .endBlock()
+            .build();
+
+        Method usingValidator = new MethodBuilder().withModifiers(Types.modifiersToInt(Modifier.PUBLIC))
+            .withReturnType(builderType.toInternalReference())
+            .withName("usingValidator")
+            .addNewArgument().withName("validator").withTypeRef(validatorRef).endArgument()
+            .withNewBlock()
+            .addNewStringStatementStatement("return new " + builderType.getName() + "(this, validator);")
+            .endBlock()
+            .build();
+
+        BuilderContext context = BuilderContextManager.getContext();
+        methods.add(usingValidation);
+        if (context.isExternalvalidatorSupported()) {
+          methods.add(usingValidator);
+        }
         constructors.add(validatorConstructor);
-        constructors.add(instanceAndFluentAndValidatorCosntructor);
+        constructors.add(instanceAndFluentAndValidatorConstructor);
         constructors.add(instanceAndValidatorConstructor);
+        constructors.add(fluentAndValidatorConstructor);
       }
 
       return BuilderContextManager.getContext().getDefinitionRepository()

--- a/examples/validation/src/test/java/io/sundr/examples/validation/AddressValidationTest.java
+++ b/examples/validation/src/test/java/io/sundr/examples/validation/AddressValidationTest.java
@@ -26,18 +26,48 @@ public class AddressValidationTest {
 
   Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
-  @Test(expected = ConstraintViolationException.class)
-  public void testWithNullStreet() {
+  @Test
+  public void shouldAcceptNullStreet() {
     Address address = new AddressBuilder().build();
   }
 
   @Test(expected = ConstraintViolationException.class)
-  public void testWithZeroNumber() {
+  public void shouldNotAcceptNullStreetViaConstructor() {
+    Address address = new AddressBuilder(true).build();
+  }
+
+  @Test(expected = ConstraintViolationException.class)
+  public void shouldNotAcceptNullStreetViaUsingValidation() {
+    Address address = new AddressBuilder().usingValidation().build();
+  }
+
+  @Test(expected = ConstraintViolationException.class)
+  public void shouldNotAcceptNullStreetViaUsingValidator() {
+    Address address = new AddressBuilder().usingValidator(validator).build();
+  }
+
+  @Test
+  public void shouldAcceptZeroNumber() {
     Address address = new AddressBuilder().withStreet("Sesame").withNumber(0).build();
   }
 
   @Test(expected = ConstraintViolationException.class)
-  public void testWithAlphanumericZipCode() {
+  public void shouldNotAcceptZeroNumberViaConstructor() {
+    Address address = new AddressBuilder(true).withStreet("Sesame").withNumber(0).build();
+  }
+
+  @Test(expected = ConstraintViolationException.class)
+  public void shouldNotAcceptZeroNumberViaUsingValidation() {
+    Address address = new AddressBuilder().withStreet("Sesame").withNumber(0).usingValidation().build();
+  }
+
+  @Test(expected = ConstraintViolationException.class)
+  public void shoulNotdAcceptZeroNumberViaUsingValidator() {
+    Address address = new AddressBuilder().withStreet("Sesame").withNumber(0).usingValidator(validator).build();
+  }
+
+  @Test
+  public void shouldAcceptAlphanumericZipCode() {
     Address address = new AddressBuilder().withStreet("Sesame")
         .withNumber(1)
         .withZipCode("abcd")
@@ -45,35 +75,63 @@ public class AddressValidationTest {
   }
 
   @Test(expected = ConstraintViolationException.class)
-  public void testWithLongZipCode() {
+  public void shouldNotAcceptAlphanumericZipCodeViaConstructor() {
+    Address address = new AddressBuilder(true).withStreet("Sesame")
+        .withNumber(1)
+        .withZipCode("abcd")
+        .build();
+  }
+
+  @Test(expected = ConstraintViolationException.class)
+  public void shouldNotAcceptAlphanumericZipCodeViaUsingValidation() {
+    Address address = new AddressBuilder().withStreet("Sesame")
+        .withNumber(1)
+        .withZipCode("abcd")
+        .usingValidation()
+        .build();
+  }
+
+  @Test(expected = ConstraintViolationException.class)
+  public void shouldNotAcceptAlphanumericZipCodeViaUsingValidator() {
+    Address address = new AddressBuilder().withStreet("Sesame")
+        .withNumber(1)
+        .withZipCode("abcd")
+        .usingValidator(validator)
+        .build();
+  }
+
+  @Test
+  public void shouldAcceptLongZipCode() {
     Address address = new AddressBuilder().withStreet("Sesame")
         .withNumber(1)
         .withZipCode("1234567")
         .build();
   }
 
-  @Test
-  public void testWithExplicitlySkippingValidation() {
-    Address address = new AddressBuilder(false).withStreet("Sesame")
+  @Test(expected = ConstraintViolationException.class)
+  public void shouldNotAcceptLongZipCodeViaConstructor() {
+    Address address = new AddressBuilder(true).withStreet("Sesame")
         .withNumber(1)
         .withZipCode("1234567")
         .build();
   }
 
-  @Test
-  public void testWithValid() {
-    Address address = new AddressBuilder().withStreet("Sesame")
+  @Test(expected = ConstraintViolationException.class)
+  public void shouldNotAcceptLongZipCodeViaUsingValidation() {
+    Address address = new AddressBuilder(true).withStreet("Sesame")
         .withNumber(1)
-        .withZipCode("1234")
+        .withZipCode("1234567")
+        .usingValidation()
         .build();
   }
 
-  @Test
-  public void testWithValidWithOwnValidator() {
-    Address address = new AddressBuilder(validator)
-        .withStreet("Sesame")
+  @Test(expected = ConstraintViolationException.class)
+  public void shouldNotAcceptLongZipCodeViaUsingValidator() {
+    Address address = new AddressBuilder(true).withStreet("Sesame")
         .withNumber(1)
-        .withZipCode("1234")
+        .withZipCode("1234567")
+        .usingValidator(validator)
         .build();
   }
+
 }


### PR DESCRIPTION
This pull request changes the following:

- Validation is now disabled via default and only applied when explicitly specified (essentially resolves: #42).
- Validation is now controlled via the DSL in addition to constructor arguments.