### PR TITLE
Preserve annotations on the class level in the reflect adapter

### DIFF
--- a/adapters/api/src/test/java/io/sundr/adapter/testing/AbstractAdapterTest.java
+++ b/adapters/api/src/test/java/io/sundr/adapter/testing/AbstractAdapterTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import io.sundr.adapter.api.AdapterContext;
 import io.sundr.adapter.api.Adapters;
 import io.sundr.adapter.testing.general.ClassWithAnnotation;
+import io.sundr.adapter.testing.general.ClassWithAnnotation2;
 import io.sundr.adapter.testing.general.ClassWithArray;
 import io.sundr.adapter.testing.general.ClassWithParam;
 import io.sundr.adapter.testing.general.ClassWithPrimitiveArray;
@@ -160,6 +161,17 @@ public abstract class AbstractAdapterTest<T> {
     assertEquals("bar", annotationRef.getParameters().get("name"));
     Object params = annotationRef.getParameters().get("values");
     assertArrayEquals(new int[] { 1, 2, 3, 5, 7 }, (int[]) annotationRef.getParameters().get("values"));
+  }
+
+  @Test
+  public void testClassWithClassAnnotations() {
+    T input = getInput(ClassWithAnnotation2.class);
+    TypeDef typeDef = Adapters.adaptType(input, getContext());
+    List<AnnotationRef> annotations = typeDef.getAnnotations();
+    assertEquals(1, annotations.size());
+    AnnotationRef annotationRef = annotations.get(0);
+    assertTrue(annotationRef.toString().contains("SimpleAnnotation2"));
+    assertEquals("baz", annotationRef.getParameters().get("name"));
   }
 
   //

--- a/adapters/api/src/test/java/io/sundr/adapter/testing/general/ClassWithAnnotation2.java
+++ b/adapters/api/src/test/java/io/sundr/adapter/testing/general/ClassWithAnnotation2.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2015 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.sundr.adapter.testing.general;
+
+@SimpleAnnotation2(name = "baz")
+public class ClassWithAnnotation2 {
+}

--- a/adapters/api/src/test/java/io/sundr/adapter/testing/general/SimpleAnnotation2.java
+++ b/adapters/api/src/test/java/io/sundr/adapter/testing/general/SimpleAnnotation2.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2015 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+package io.sundr.adapter.testing.general;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ TYPE, TYPE_USE })
+@Retention(RUNTIME)
+public @interface SimpleAnnotation2 {
+  String name();
+
+  int[] values() default {};
+}


### PR DESCRIPTION
This should reduce the cons discovered in:
https://github.com/fabric8io/kubernetes-client/pull/3797

cc. @iocanel @metacosm 