### PR TITLE
Further improve Visitor

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/annotations/ExternalBuildables.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/annotations/ExternalBuildables.java
@@ -55,6 +55,7 @@ public @interface ExternalBuildables {
 
   /**
    * Ignore properties
+   * 
    * @return the names of the properties to ignore.
    */
   String[] ignore() default {};

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
@@ -355,27 +355,21 @@ public class ClazzAs {
           .withReturnType(Types.PRIMITIVE_BOOLEAN_REF).addNewArgument().withName("o")
           .withTypeRef(Types.OBJECT.toReference()).endArgument().withName("equals").withNewBlock()
           .withStatements(BuilderUtils.toEquals(fluentImplType, properties)).endBlock()
-          // .withBlock(new Block(new Provider<List<Statement>>() {
-          //   @Override
-          //   public List<Statement> get() {
-          //     return BuilderUtils.toEquals(fluentImplType, properties);
-          //   }
-          // }))
           .build();
 
       Method hashCode = new MethodBuilder().withModifiers(Types.modifiersToInt(Modifier.PUBLIC))
           .withReturnType(io.sundr.model.utils.Types.PRIMITIVE_INT_REF).withName("hashCode").withNewBlock()
           .withStatements(BuilderUtils.toHashCode(properties)).endBlock()
-          // .withBlock(new Block(new Provider<List<Statement>>() {
-          //   @Override
-          //   public List<Statement> get() {
-          //     return BuilderUtils.toHashCode(properties);
-          //   }
-          // }))
+          .build();
+
+      Method toString = new MethodBuilder().withModifiers(Types.modifiersToInt(Modifier.PUBLIC))
+          .withReturnType(io.sundr.model.utils.Types.STRING_REF).withName("toString").withNewBlock()
+          .withStatements(BuilderUtils.toString(fluentImplType.getName(), properties)).endBlock()
           .build();
 
       methods.add(equals);
       methods.add(hashCode);
+      methods.add(toString);
 
       return BuilderContextManager.getContext().getDefinitionRepository()
           .register(

--- a/core/src/main/java/io/sundr/builder/PathAwareTypedVisitor.java
+++ b/core/src/main/java/io/sundr/builder/PathAwareTypedVisitor.java
@@ -16,64 +16,76 @@
 
 package io.sundr.builder;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.lang.reflect.Method;
 import java.util.List;
 
-public class PathAwareTypedVisitor<V, P> extends TypedVisitor<V> {
+public class PathAwareTypedVisitor<V, P> implements Visitor<V> {
 
-  private List<Object> path;
-  private final PathAwareTypedVisitor<V, P> delegate;
+  private final Class<V> type;
   private final Class<P> parentType;
 
   public PathAwareTypedVisitor() {
-    this.path = new ArrayList<Object>();
-    this.delegate = this;
-    this.parentType = (Class<P>) Visitor.getTypeArguments(PathAwareTypedVisitor.class, getClass()).get(1);
-  }
-
-  public PathAwareTypedVisitor(List<Object> path) {
-    this.path = path;
-    this.delegate = this;
-    this.parentType = (Class<P>) Visitor.getTypeArguments(PathAwareTypedVisitor.class, getClass()).get(1);
-  }
-
-  public PathAwareTypedVisitor(List<Object> path, PathAwareTypedVisitor<V, P> delegate) {
-    this.path = path;
-    this.delegate = delegate;
-    this.parentType = (Class<P>) Visitor.getTypeArguments(PathAwareTypedVisitor.class, delegate.getClass()).get(1);
-  }
-
-  public PathAwareTypedVisitor<V, P> next(Object item) {
-    List<Object> path = new ArrayList<Object>(this.path);
-    path.add(item);
-    return new PathAwareTypedVisitor<V, P>(path, this);
+    List<Class> args = Visitor.getTypeArguments(PathAwareTypedVisitor.class, getClass());
+    if (args == null || args.isEmpty()) {
+      throw new IllegalStateException("Could not determine type arguments for path aware typed visitor.");
+    }
+    this.type = (Class<V>) args.get(0);
+    this.parentType = (Class<P>) args.get(1);
   }
 
   @Override
   public void visit(V element) {
-    delegate.path = path;
-    delegate.visit(element);
   }
 
-  public P getParent() {
-    return path.size() - 2 >= 0 ? (P) path.get(path.size() - 2) : null;
+  @Override
+  public void visit(List<Object> path, V element) {
   }
 
-  public List<Object> getPath() {
-    return Collections.unmodifiableList(path);
+  @Override
+  public <F> Boolean canVisit(F target) {
+    if (target == null) {
+      return false;
+    }
+    if (getType() == null) {
+      return false;
+    } else if (!getType().isAssignableFrom(target.getClass())) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Checks if the specified visitor has a visit method compatible with the specified fluent.
+   * 
+   * @param target
+   * @param <F>
+   * @return
+   */
+  public <F> Boolean hasVisitMethodMatching(F target) {
+    for (Method method : getClass().getMethods()) {
+      if (!method.getName().equals("visit") || method.getParameterTypes().length != 2) {
+        continue;
+      }
+      Class<?> visitorType = method.getParameterTypes()[1];
+      if (visitorType.isAssignableFrom(target.getClass())) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  public P getParent(List<Object> path) {
+    return path.size() - 1 >= 0 ? (P) path.get(path.size() - 1) : null;
+  }
+
+  public Class<P> getParentType() {
+    return parentType;
   }
 
   @Override
   public Class<V> getType() {
-    return super.getType() != null ? super.getType() : delegate.getType();
-  }
-
-  public Class<P> getParentType() {
-    return parentType != null ? parentType : delegate.getParentType();
-  }
-
-  Class getActualParentType() {
-    return path.size() - 2 >= 0 ? path.get(path.size() - 2).getClass() : Void.class;
+    return type;
   }
 }

--- a/core/src/main/java/io/sundr/builder/Visitable.java
+++ b/core/src/main/java/io/sundr/builder/Visitable.java
@@ -16,6 +16,8 @@
 
 package io.sundr.builder;
 
+import java.util.List;
+
 public interface Visitable<T> {
 
   T accept(Visitor... visitor);
@@ -33,4 +35,6 @@ public interface Visitable<T> {
       }
     });
   }
+
+  T accept(List<Object> path, Visitor... visitor);
 }

--- a/model/base/src/main/java/io/sundr/model/AttributeKey.java
+++ b/model/base/src/main/java/io/sundr/model/AttributeKey.java
@@ -38,4 +38,8 @@ public final class AttributeKey<T> {
     return type;
   }
 
+  @Override
+  public String toString() {
+    return "AttributeKey [name=" + name + "]";
+  }
 }

--- a/model/base/src/main/java/io/sundr/model/Method.java
+++ b/model/base/src/main/java/io/sundr/model/Method.java
@@ -231,7 +231,7 @@ public class Method extends ModifierSupport implements Renderable, Commentable, 
     } else {
       //This is a constructor
       String fqcn = ((ClassRef) returnType).getFullyQualifiedName();
-      String className = fqcn.substring(fqcn.lastIndexOf(".") + 1);
+      String className = Nameable.getClassName(fqcn);
       sb.append(className);
     }
 

--- a/model/base/src/main/java/io/sundr/model/Nameable.java
+++ b/model/base/src/main/java/io/sundr/model/Nameable.java
@@ -19,6 +19,7 @@ package io.sundr.model;
 
 import java.util.Arrays;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public interface Nameable extends Node {
@@ -52,6 +53,16 @@ public interface Nameable extends Node {
    */
   default String getPackageName() {
     return getPackageName(getFullyQualifiedName());
+  }
+
+  static String getOuterTypeName(String fullyQualifiedName) {
+    String packageName = getPackageName(fullyQualifiedName);
+    String className = getClassName(fullyQualifiedName);
+    if (!className.contains(DOT)) {
+      return null;
+    }
+    return Arrays.stream(className.split(Pattern.quote(DOT)))
+        .map(n -> packageName != null && !packageName.isEmpty() ? packageName + DOT + n : n).findFirst().orElse(null);
   }
 
   static String getClassName(String fullyQualifiedName) {

--- a/model/base/src/main/java/io/sundr/model/TypeDef.java
+++ b/model/base/src/main/java/io/sundr/model/TypeDef.java
@@ -88,7 +88,7 @@ public class TypeDef extends ModifierSupport implements Renderable, Nameable, An
     this.constructors = Collections.emptyList();
     this.methods = Collections.emptyList();
     this.innerTypes = Collections.emptyList();
-    this.outerTypeName = null;
+    this.outerTypeName = Nameable.getOuterTypeName(fullyQualifiedName);
   }
 
   public static TypeDef forName(String fullyQualifiedName) {

--- a/model/base/src/main/java/io/sundr/model/TypeDef.java
+++ b/model/base/src/main/java/io/sundr/model/TypeDef.java
@@ -68,10 +68,11 @@ public class TypeDef extends ModifierSupport implements Renderable, Nameable, An
     this.implementsList = implementsList;
     this.parameters = parameters;
     this.properties = properties;
-    this.constructors = adaptConstructors(constructors, this);
     this.methods = methods;
     this.outerTypeName = outerTypeName;
+    //Adapters should be added last as the depend on previous values
     this.innerTypes = setOuterType(innerTypes, this);
+    this.constructors = adaptConstructors(constructors, this);
   }
 
   protected TypeDef(String fullyQualifiedName) {

--- a/model/base/src/main/java/io/sundr/model/TypeDef.java
+++ b/model/base/src/main/java/io/sundr/model/TypeDef.java
@@ -302,12 +302,17 @@ public class TypeDef extends ModifierSupport implements Renderable, Nameable, An
   }
 
   public Set<String> getImports() {
+    return getImports(getReferenceMap().values());
+  }
+
+  private Set<String> getImports(Collection<ClassRef> references) {
     final Set<String> imports = new LinkedHashSet<String>();
-    for (ClassRef ref : getReferenceMap().values()) {
+    for (ClassRef ref : references) {
       if (ref.getPackageName() == null ||
           ref.getPackageName().isEmpty() ||
           ref.getPackageName().equals(packageName) ||
-          ref.getName().equals(name)) {
+          ref.getName().equals(name) ||
+          ref.getFullyQualifiedName().equals(getFullyQualifiedName())) {
         continue;
       } else if (ref.getFullyQualifiedName().startsWith("com.ibm.jit.JITHelpers")
           || ref.getFullyQualifiedName().equals("java.lang.StringCompressionFlag")) {
@@ -428,12 +433,13 @@ public class TypeDef extends ModifierSupport implements Renderable, Nameable, An
     StringBuilder sb = new StringBuilder();
     String indent = outerTypeName == null ? "  " : "    ";
     String halfIndent = outerTypeName == null ? "" : "  ";
+    Collection<ClassRef> references = getReferenceMap().values();
 
     // We only need to render those for the outermost type
     if (outerTypeName == null) {
       tb.append("package ").append(getPackageName()).append(SEMICOLN).append(NEWLINE);
       tb.append(NEWLINE);
-      for (String i : getImports()) {
+      for (String i : getImports(references)) {
         tb.append("import ").append(i).append(SEMICOLN).append(NEWLINE);
       }
     }
@@ -484,7 +490,8 @@ public class TypeDef extends ModifierSupport implements Renderable, Nameable, An
     sb.append(NEWLINE).append(halfIndent).append(CB);
     String top = tb.toString();
     String content = sb.toString();
-    for (ClassRef ref : getReferences()) {
+    for (ClassRef ref : references) {
+      //If class is imported
       if (top.contains("import " + ref.getFullyQualifiedName() + ";") || ref.getPackageName().equals(getPackageName())) {
         content = content.replaceFirst(Pattern.quote(ref.getFullyQualifiedName()), ref.getName());
       }

--- a/model/base/src/test/java/io/sundr/model/NameableTest.java
+++ b/model/base/src/test/java/io/sundr/model/NameableTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2015 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.sundr.model;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class NameableTest {
+
+  @Test
+  public void shouldGetClassName() {
+    assertEquals("Void", Nameable.getClassName("Void"));
+    assertEquals("List", Nameable.getClassName("java.util.List"));
+    assertEquals("System.Logger", Nameable.getClassName("java.lang.System.Logger"));
+  }
+
+  @Test
+  public void shouldGetOuterTypeName() {
+    assertEquals(null, Nameable.getOuterTypeName("Void"));
+    assertEquals(null, Nameable.getOuterTypeName("java.util.List"));
+    assertEquals("java.lang.System", Nameable.getOuterTypeName("java.lang.System.Logger"));
+  }
+}

--- a/model/utils/src/main/java/io/sundr/model/functions/GetDefinition.java
+++ b/model/utils/src/main/java/io/sundr/model/functions/GetDefinition.java
@@ -17,15 +17,10 @@
 
 package io.sundr.model.functions;
 
-import static io.sundr.utils.Predicates.after;
-import static io.sundr.utils.Predicates.until;
-
-import java.util.Arrays;
 import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import io.sundr.model.ClassRef;
+import io.sundr.model.Nameable;
 import io.sundr.model.TypeDef;
 import io.sundr.model.TypeDefBuilder;
 import io.sundr.model.repo.DefinitionRepository;
@@ -49,27 +44,16 @@ public class GetDefinition implements Function<ClassRef, TypeDef> {
     if (def != null) {
       return def;
     }
-    Predicate<String> isLowerCase = w -> Character.isUpperCase(w.charAt(0));
-    Predicate<String> inPackage = until(isLowerCase);
-    Predicate<String> outOfPackage = after(isLowerCase);
 
-    String packageName = Arrays.stream(fullyQualifiedName.split("\\.")).filter(inPackage).collect(Collectors.joining("."));
-    String className = Arrays.stream(fullyQualifiedName.split("\\.")).filter(outOfPackage).collect(Collectors.joining("."));
-
-    String ownerClassName = className.contains(".") ? className.substring(0, className.indexOf(".")) : null;
-
-    if (ownerClassName != null) {
-      className = className.substring(ownerClassName.length() + 1);
-      return new TypeDefBuilder()
-          .withName(className)
-          .withPackageName(packageName)
-          .withOuterTypeName(packageName + "." + ownerClassName)
-          .build();
-    }
+    String packageName = Nameable.getPackageName(fullyQualifiedName);
+    String className = Nameable.getClassName(fullyQualifiedName);
+    String outerTypeName = Nameable.getOuterTypeName(fullyQualifiedName);
 
     return new TypeDefBuilder()
         .withName(className)
         .withPackageName(packageName)
+        .withOuterTypeName(outerTypeName)
         .build();
   }
+
 }

--- a/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
+++ b/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
@@ -17,6 +17,7 @@
 package io.sundr.examples.shapes;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.Assert;
@@ -85,7 +86,8 @@ public class ShapesTest {
 
     canvas = new CanvasBuilder(canvas).accept(new PathAwareTypedVisitor<CircleBuilder<Integer>, CanvasBuilder>() {
       @Override
-      public void visit(CircleBuilder<Integer> builder) {
+      public void visit(List<Object> path, CircleBuilder<Integer> builder) {
+        System.out.println("path:" + path);
         builder.withRadius(100 + builder.getRadius());
       }
     }).build();


### PR DESCRIPTION
This is a follow up on #303 which further improves the classes around the visitor concept, by removing code that was out of place and make some concept less confusing. In detail:

- can visit methods moved from Visitable/BaseFluent to Visitor
- Removed all PathAwareVisitor handling from Visitable/BaseFluent
- All Visitors are now path aware.
- PathAwareVisitor is now a just visitor with a fixed parent type and parent extracting methods.

