### PR TITLE
chore: Change distribution from adopt to temurin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,13 @@ jobs:
         profile: [normal, with-swagger]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Build Project
         run: |
           if [ -f $JAVA_HOME/lib/tools.jar ]; then


### PR DESCRIPTION
Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore.