### PR TITLE
TypeArguments: eliminate StackOverflow while retaining accurate types

### DIFF
--- a/model/utils/src/main/java/io/sundr/model/utils/TypeArguments.java
+++ b/model/utils/src/main/java/io/sundr/model/utils/TypeArguments.java
@@ -99,6 +99,10 @@ public class TypeArguments {
     }
 
     List<TypeParamDef> parameters = definition.getParameters();
+    if (parameters.size() != arguments.size()) {
+      throw new IllegalStateException("Incompatible reference " + ref + " to " + definition);
+    }
+
     Map<String, TypeRef> mappings = new HashMap<>();
     for (int i = 0; i < arguments.size(); i++) {
       String name = parameters.get(i).getName();

--- a/model/utils/src/main/java/io/sundr/model/visitors/ApplyTypeParamMappingToTypeArguments.java
+++ b/model/utils/src/main/java/io/sundr/model/visitors/ApplyTypeParamMappingToTypeArguments.java
@@ -17,17 +17,23 @@
 
 package io.sundr.model.visitors;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import io.sundr.builder.Visitor;
+import io.sundr.model.AttributeKey;
+import io.sundr.model.ClassRef;
+import io.sundr.model.ClassRefBuilder;
 import io.sundr.model.ClassRefFluent;
 import io.sundr.model.TypeParamRef;
 import io.sundr.model.TypeRef;
 import io.sundr.utils.Maps;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ApplyTypeParamMappingToTypeArguments implements Visitor<ClassRefFluent<?>> {
+  private static final AttributeKey<TypeParamRef> ALREADY_REPLACED_KEY
+          = new AttributeKey<>(ApplyTypeParamMappingToTypeArguments.class.getName() + ".ALREADY_REPLACED", boolean.class);
+
   private final Map<String, TypeRef> mappings;
 
   public ApplyTypeParamMappingToTypeArguments(String name, TypeRef typeRef) {
@@ -35,11 +41,14 @@ public class ApplyTypeParamMappingToTypeArguments implements Visitor<ClassRefFlu
   }
 
   public ApplyTypeParamMappingToTypeArguments(Map<String, TypeRef> mappings) {
-    this.mappings = mappings;
+    this.mappings = markTypeParamRefs(mappings);
   }
 
   @Override
   public void visit(ClassRefFluent<?> classRef) {
+    if (classRef.hasAttributes() && classRef.getAttributes().remove(ALREADY_REPLACED_KEY) != null) {
+      return;
+    }
     List<TypeRef> arguments = new ArrayList<>();
     for (TypeRef arg : classRef.buildArguments()) {
       TypeRef mappedRef = arg;
@@ -55,4 +64,26 @@ public class ApplyTypeParamMappingToTypeArguments implements Visitor<ClassRefFlu
     classRef.withArguments(arguments);
   }
 
+  /**
+   * This is to handle cyclic mappings, like {@code V -> List<V>}.
+   * <p>
+   * If unhandled, these would get expanded infinitely into {@code List<List<List<...>>>}.
+   * <p>
+   * To prevent this, each mapping target is marked with an attribute that stops further expansion. The attribute is removed in
+   * {@link #visit(ClassRefFluent)}
+   *
+   * @param mappings
+   *         Type argument replacement mappings
+   * @return Mapping with values marked by an attribute
+   */
+  private static Map<String, TypeRef> markTypeParamRefs(Map<String, TypeRef> mappings) {
+    Map<String, TypeRef> result = new HashMap<>(mappings.size());
+    mappings.forEach((key, target) -> {
+      if (target instanceof ClassRef) {
+        target = new ClassRefBuilder((ClassRef) target).addToAttributes(ALREADY_REPLACED_KEY, true).build();
+      }
+      result.put(key, target);
+    });
+    return result;
+  }
 }

--- a/model/utils/src/test/java/io/sundr/model/utils/TypeArgumentsTest.java
+++ b/model/utils/src/test/java/io/sundr/model/utils/TypeArgumentsTest.java
@@ -1,44 +1,127 @@
 package io.sundr.model.utils;
 
+import static io.sundr.model.utils.Collections.E;
 import static io.sundr.model.utils.Collections.K;
 import static io.sundr.model.utils.Collections.V;
+import static io.sundr.model.utils.Types.OPTIONAL;
+import static io.sundr.model.utils.Types.VOID;
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
+import io.sundr.builder.Visitor;
 import io.sundr.model.ClassRef;
 import io.sundr.model.Kind;
+import io.sundr.model.Method;
+import io.sundr.model.Property;
+import io.sundr.model.RichTypeDef;
 import io.sundr.model.TypeDef;
 import io.sundr.model.TypeDefBuilder;
+import io.sundr.model.TypeRef;
 import io.sundr.model.functions.GetDefinition;
 import io.sundr.model.repo.DefinitionRepository;
+import io.sundr.utils.Strings;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
 
 // Credits to: Dusan Jakub (xRodney).
 public class TypeArgumentsTest {
-  public static final TypeDef MULTI_HASH_MAP = new TypeDefBuilder(TypeDef.forName("com.example.MultiHashMap"))
-      .withKind(Kind.CLASS)
-      .withParameters(K, V)
-      .withExtendsList(Collections.HASH_MAP.toReference(K.toReference(), Collections.LIST.toReference(V.toReference())))
-      .build();
 
-  @Test
-  public void shouldNotCauseStackOverflow() {
-    DefinitionRepository.getRepository().register(Collections.MAP);
-    DefinitionRepository.getRepository().register(Collections.HASH_MAP);
-    DefinitionRepository.getRepository().register(Collections.LIST);
-    DefinitionRepository.getRepository().register(Types.STRING);
-    DefinitionRepository.getRepository().register(Types.INT);
-    DefinitionRepository.getRepository().register(MULTI_HASH_MAP);
+    public static final TypeDef MULTI_HASH_MAP = new TypeDefBuilder(TypeDef.forName("com.example.MultiHashMap"))
+            .withKind(Kind.CLASS).withParameters(K, V)
+            .withExtendsList(
+                    Collections.HASH_MAP.toReference(K.toReference(), Collections.LIST.toReference(V.toReference())))
+            .build();
 
-    ClassRef classRef = MULTI_HASH_MAP.toReference(Types.STRING_REF, Types.INT_REF);
-    TypeDef typeDef = GetDefinition.of(classRef);
-    TypeDef richDef = TypeArguments.apply(GetDefinition.of(classRef));
+    public static final TypeDef MY_SUPERCLASS = new TypeDefBuilder(TypeDef.forName("com.example.MySuperclass"))
+            .withKind(Kind.CLASS).withParameters(E)
+            .accept(addBackedProperty(E.toReference(), "superValue"))
+            .accept(addBackedProperty(Collections.LIST.toReference(E.toReference()), "superValues"))
+            .build();
 
-    System.out.println(typeDef.render());
-    System.out.println(richDef.render());
+    public static final TypeDef MY_SUBCLASS = new TypeDefBuilder(TypeDef.forName("com.example.MySubclass"))
+            .withKind(Kind.CLASS).withParameters(E)
+            .accept(addBackedProperty(E.toReference(), "subValue"))
+            .accept(addBackedProperty(Collections.LIST.toReference(E.toReference()), "subValues"))
+            .withExtendsList(MY_SUPERCLASS.toReference(OPTIONAL.toReference(E.toReference())))
+            .build();
 
-    // This goes beyond the purpose of the tests, which is to check against SO.
-    // Still, it's nice to know that the rendered code is not affected (for THIS scenario).
-    assertEquals(typeDef.render(), richDef.render());
-  }
+    @Before
+    public void setUp() {
+        DefinitionRepository.getRepository().register(Collections.MAP);
+        DefinitionRepository.getRepository().register(Collections.HASH_MAP);
+        DefinitionRepository.getRepository().register(Collections.LIST);
+        DefinitionRepository.getRepository().register(Types.STRING);
+        DefinitionRepository.getRepository().register(Types.INT);
+        DefinitionRepository.getRepository().register(MULTI_HASH_MAP);
+        DefinitionRepository.getRepository().register(MY_SUBCLASS);
+        DefinitionRepository.getRepository().register(MY_SUPERCLASS);
+    }
+
+    @Test
+    public void shouldNotCauseStackOverflow() {
+        ClassRef classRef = MULTI_HASH_MAP.toReference(Types.STRING_REF, Types.INT_REF);
+        TypeDef typeDef = GetDefinition.of(classRef);
+        RichTypeDef richDef = TypeArguments.apply(GetDefinition.of(classRef));
+
+        System.out.println(typeDef.render());
+        System.out.println(richDef.render());
+
+        // This goes beyond the purpose of the tests, which is to check against SO.
+        // Still, it's nice to know that the rendered code is not affected (for THIS scenario).
+        assertEquals(typeDef.render(), richDef.render());
+    }
+
+    @Test
+    public void propertiesAndMethodsFromSupertypesAreResolvedCorrectly() {
+        ClassRef classRef = MY_SUBCLASS.toReference(Types.STRING_REF);
+        TypeDef typeDef = GetDefinition.of(classRef);
+        RichTypeDef richDef = TypeArguments.apply(GetDefinition.of(classRef));
+
+        System.out.println(typeDef.render());
+        System.out.println(richDef.render());
+
+        Map<String, Property> propertiesByName = richDef.getAllProperties().stream()
+                .collect(Collectors.toMap(Property::getName, Function.identity()));
+        assertEquals(4, propertiesByName.size());
+        assertEquals("E subValue", propertiesByName.get("subValue").render());
+        assertEquals("java.util.List<E> subValues", propertiesByName.get("subValues").render());
+        assertEquals("java.util.Optional<E> superValue", propertiesByName.get("superValue").render());
+        assertEquals("java.util.List<java.util.Optional<E>> superValues", propertiesByName.get("superValues").render());
+
+        Map<String, Method> methodsByName = richDef.getAllMethods().stream()
+                .collect(Collectors.toMap(Method::getName, Function.identity()));
+        assertEquals(8, methodsByName.size());
+
+        assertEquals("E getSubValue();", methodsByName.get("getSubValue").render());
+        assertEquals("void setSubValue(E subValue);", methodsByName.get("setSubValue").render());
+        assertEquals("java.util.List<E> getSubValues();", methodsByName.get("getSubValues").render());
+        assertEquals("void setSubValues(java.util.List<E> subValues);", methodsByName.get("setSubValues").render());
+
+        assertEquals("java.util.Optional<E> getSuperValue();", methodsByName.get("getSuperValue").render());
+        assertEquals("void setSuperValue(java.util.Optional<E> superValue);",
+                methodsByName.get("setSuperValue").render());
+        assertEquals("java.util.List<java.util.Optional<E>> getSuperValues();",
+                methodsByName.get("getSuperValues").render());
+        assertEquals("void setSuperValues(java.util.List<java.util.Optional<E>> superValues);",
+                methodsByName.get("setSuperValues").render());
+    }
+
+    /**
+     * Register a field with a type and name, and corresponding getter and setter methods
+     */
+    private static Visitor<TypeDefBuilder> addBackedProperty(TypeRef type, String name) {
+        return new Visitor<TypeDefBuilder>() {
+            @Override
+            public void visit(TypeDefBuilder typeDef) {
+                typeDef.addNewProperty().withName(name).withTypeRef(type).endProperty()
+
+                        .addNewMethod().withName("get" + Strings.capitalizeFirst(name)).withReturnType(type).endMethod()
+
+                        .addNewMethod().withName("set" + Strings.capitalizeFirst(name)).withVoidRefReturnType(VOID)
+                        .addNewArgument().withTypeRef(type).withName(name).endArgument().endMethod();
+            }
+        };
+    }
 }

--- a/model/utils/src/test/java/io/sundr/model/utils/TypeArgumentsTest.java
+++ b/model/utils/src/test/java/io/sundr/model/utils/TypeArgumentsTest.java
@@ -4,6 +4,7 @@ import static io.sundr.model.utils.Collections.E;
 import static io.sundr.model.utils.Collections.K;
 import static io.sundr.model.utils.Collections.V;
 import static io.sundr.model.utils.Types.OPTIONAL;
+import static io.sundr.model.utils.Types.STRING_REF;
 import static io.sundr.model.utils.Types.VOID;
 import static org.junit.Assert.assertEquals;
 
@@ -74,8 +75,8 @@ public class TypeArgumentsTest {
     }
 
     @Test
-    public void propertiesAndMethodsFromSupertypesAreResolvedCorrectly() {
-        ClassRef classRef = MY_SUBCLASS.toReference(Types.STRING_REF);
+    public void propertiesAndMethodsFromSupertypesAreResolvedCorrectlyOnTypeDefinition() {
+        ClassRef classRef = MY_SUBCLASS.toReference();
         TypeDef typeDef = GetDefinition.of(classRef);
         RichTypeDef richDef = TypeArguments.apply(GetDefinition.of(classRef));
 
@@ -105,6 +106,39 @@ public class TypeArgumentsTest {
         assertEquals("java.util.List<java.util.Optional<E>> getSuperValues();",
                 methodsByName.get("getSuperValues").render());
         assertEquals("void setSuperValues(java.util.List<java.util.Optional<E>> superValues);",
+                methodsByName.get("setSuperValues").render());
+    }
+
+    @Test
+    public void propertiesAndMethodsFromSupertypesAreResolvedCorrectlyOnTypeReference() {
+        ClassRef classRef = MY_SUBCLASS.toReference(STRING_REF);
+        RichTypeDef richDef = TypeArguments.apply(classRef);
+
+        System.out.println(richDef.render());
+
+        Map<String, Property> propertiesByName = richDef.getAllProperties().stream()
+                .collect(Collectors.toMap(Property::getName, Function.identity()));
+        assertEquals(4, propertiesByName.size());
+        assertEquals("java.lang.String subValue", propertiesByName.get("subValue").render());
+        assertEquals("java.util.List<java.lang.String> subValues", propertiesByName.get("subValues").render());
+        assertEquals("java.util.Optional<java.lang.String> superValue", propertiesByName.get("superValue").render());
+        assertEquals("java.util.List<java.util.Optional<java.lang.String>> superValues", propertiesByName.get("superValues").render());
+
+        Map<String, Method> methodsByName = richDef.getAllMethods().stream()
+                .collect(Collectors.toMap(Method::getName, Function.identity()));
+        assertEquals(8, methodsByName.size());
+
+        assertEquals("java.lang.String getSubValue();", methodsByName.get("getSubValue").render());
+        assertEquals("void setSubValue(java.lang.String subValue);", methodsByName.get("setSubValue").render());
+        assertEquals("java.util.List<java.lang.String> getSubValues();", methodsByName.get("getSubValues").render());
+        assertEquals("void setSubValues(java.util.List<java.lang.String> subValues);", methodsByName.get("setSubValues").render());
+
+        assertEquals("java.util.Optional<java.lang.String> getSuperValue();", methodsByName.get("getSuperValue").render());
+        assertEquals("void setSuperValue(java.util.Optional<java.lang.String> superValue);",
+                methodsByName.get("setSuperValue").render());
+        assertEquals("java.util.List<java.util.Optional<java.lang.String>> getSuperValues();",
+                methodsByName.get("getSuperValues").render());
+        assertEquals("void setSuperValues(java.util.List<java.util.Optional<java.lang.String>> superValues);",
                 methodsByName.get("setSuperValues").render());
     }
 


### PR DESCRIPTION
Fixes sundrio/sundrio#333.

While the original fix replaced the recursive mapping `V -> List<V>` with `V -> List<?>`, here I take a more subtle approach. The mapping is replaced with `V -> List<V>[replaced=true]`, where he `[replaced=true]` is an attribute. The visitor never replaces class refs with this attribute and while doing so also removes it, so that the resulting type tree is clean.

Because the goal of this is to be usable in `crd-generator`, I also added a new convenience method `RichTypeDef apply(ClassRef)` (I actually renamed a pre-existing private method with the same name to make room for it). This can process the types all the way from a generic reference (as opposed to from a definition)

Related: fabric8io/kubernetes-client#4357