### PR TITLE
Fix TypeAs.UNWRAP_MAP_VALUE_OF and TypeAs.UNWRAP_MAP_KEY_OF

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/TypeAs.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/TypeAs.java
@@ -215,12 +215,8 @@ public class TypeAs {
   public static final Function<TypeRef, TypeRef> ARRAY_AS_LIST = FunctionFactory
       .cache(item -> LIST_OF.apply(UNWRAP_ARRAY_OF.apply(item)));
 
-  public static final Function<TypeRef, TypeRef> UNWRAP_COLLECTION_OF = type -> {
-    if (type instanceof ClassRef) {
-      return extractArgument((ClassRef) type, Collections.IS_COLLECTION, 0).orElse(type);
-    }
-    return type;
-  };
+  public static final Function<TypeRef, TypeRef> UNWRAP_COLLECTION_OF = type -> Collections.getCollectionElementType(type)
+      .orElse(type);
 
   private static Optional<TypeRef> extractArgument(ClassRef classRef, Function<TypeRef, Boolean> typeCheckFn,
       int argumentIndex) {
@@ -240,16 +236,9 @@ public class TypeAs {
     }
   }
 
-  private static TypeRef unwrapMapOf(TypeRef type, int argumentIndex) {
-    if (type instanceof ClassRef) {
-      return extractArgument((ClassRef) type, Collections.IS_MAP, argumentIndex).orElse(type);
-    }
-    return type;
-  }
+  public static final Function<TypeRef, TypeRef> UNWRAP_MAP_KEY_OF = type -> Collections.getMapKeyType(type).orElse(type);
 
-  public static final Function<TypeRef, TypeRef> UNWRAP_MAP_KEY_OF = type -> unwrapMapOf(type, 0);
-
-  public static final Function<TypeRef, TypeRef> UNWRAP_MAP_VALUE_OF = type -> unwrapMapOf(type, 1);
+  public static final Function<TypeRef, TypeRef> UNWRAP_MAP_VALUE_OF = type -> Collections.getMapValueType(type).orElse(type);
 
   public static final Function<TypeRef, TypeRef> UNWRAP_OPTIONAL_OF = type -> {
     if (type instanceof ClassRef) {

--- a/annotations/builder/src/test/java/io/sundr/builder/internal/processor/SimpleClassTest.java
+++ b/annotations/builder/src/test/java/io/sundr/builder/internal/processor/SimpleClassTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Iterator;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -41,6 +42,7 @@ public class SimpleClassTest extends AbstractProcessorTest {
   private final AdapterContext context = AdapterContext.create(DefinitionRepository.getRepository());
 
   TypeDef stringDef = Adapters.adaptType(String.class, context);
+  TypeDef listDef = Adapters.adaptType(List.class, context);
   RichTypeDef simpleClassDef = TypeArguments.apply(Sources.readTypeDefFromResource("SimpleClass.java", context));
 
   @Test

--- a/model/utils/src/main/java/io/sundr/model/functions/TypeCast.java
+++ b/model/utils/src/main/java/io/sundr/model/functions/TypeCast.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2015 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.sundr.model.functions;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.sundr.model.ClassRef;
+import io.sundr.model.ClassRefBuilder;
+import io.sundr.model.TypeDef;
+import io.sundr.model.TypeRef;
+import io.sundr.model.WildcardRef;
+import io.sundr.model.utils.TypeArguments;
+import io.sundr.model.utils.Types;
+import io.sundr.model.visitors.ApplyTypeParamMappingToTypeArguments;
+
+/**
+ * This function can be thought as {@link Types#isInstanceOf(TypeRef, TypeDef, Function)} with added bonus that generic
+ * arguments
+ * are resolved.
+ * <p>
+ * For example, when {@code TypeCast.to(Map<?,?>)} is called on {@code HashMap<String, Integer}, the result will be
+ * {@code Optional.of(Map<String, Integer>)}.
+ * <p>
+ * This works also for complex hierarchies with non-trivial type argument substitutions.
+ * <p>
+ * Limitation: Arguments involving wildcards are currently not supported.
+ */
+public class TypeCast implements Function<TypeRef, Optional<ClassRef>> {
+
+  private final ClassRef expectedType;
+
+  private TypeCast(ClassRef expectedType) {
+    this.expectedType = expectedType;
+  }
+
+  /**
+   * Create the function which casts to the specified target type.
+   *
+   * @param expectedType
+   *        The type to which to cast. It must not be an array, and all type arguments (if any) must be unbounded wildcards
+   */
+  public static TypeCast to(ClassRef expectedType) {
+    assertNoArray(expectedType);
+    assertAllArgumentsAreWildcards(expectedType);
+    return new TypeCast(expectedType);
+  }
+
+  private static void assertNoArray(ClassRef expectedType) {
+    if (expectedType.getDimensions() != 0) {
+      throw new IllegalArgumentException("Arrays are not supported: " + expectedType);
+    }
+  }
+
+  private static void assertAllArgumentsAreWildcards(ClassRef expectedType) {
+    for (TypeRef argument : expectedType.getArguments()) {
+      if (!(argument instanceof WildcardRef) || !((WildcardRef) argument).getBounds().isEmpty()) {
+        throw new IllegalArgumentException("Argument " + argument + " is not an unbounded wildcard in " + expectedType);
+      }
+    }
+  }
+
+  /**
+   * Perform the type cast, if possible.
+   *
+   * @param type
+   *        The type which will be cast
+   * @return If the type can be cast to target type, {@code Optional.of(targetType<...>)} is returned with the type arguments
+   *         resolved. If the
+   *         type cannot be cast, {@code Optional.empty()} is returned.
+   * @throws IllegalStateException
+   *         when the type implements or extends target type multiple times with different arguments. Currently, this may also
+   *         apply to multiple inheritance of wildcard types, even if they were compatible.
+   */
+  @Override
+  public Optional<ClassRef> apply(TypeRef type) {
+    if (type instanceof ClassRef) {
+      Set<ClassRef> types = findMatchingTypes((ClassRef) type).collect(Collectors.toSet());
+
+      if (types.size() > 1) {
+        throw new IllegalStateException("Type " + type +
+            " extends or implements " + expectedType + " multiple times: "
+            + types + ". This is not legal in Java");
+      }
+
+      return types.stream().findAny();
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  private Stream<ClassRef> findMatchingTypes(ClassRef type) {
+    if (type.getFullyQualifiedName().equals(expectedType.getFullyQualifiedName())) {
+      return Stream.of(type);
+    }
+
+    TypeDef definition = GetDefinition.of(type);
+    Stream<ClassRef> supertypes = Stream.concat(
+        definition.getImplementsList().stream(),
+        definition.getExtendsList().stream());
+
+    return supertypes
+        // as a corner-case, java.lang.Object extends itself:
+        .filter(supertype -> !type.equals(supertype))
+        .flatMap(this::findMatchingTypes)
+        .map(supertype -> bindArguments(type, supertype));
+  }
+
+  private ClassRef bindArguments(ClassRef type, ClassRef supertype) {
+    Map<String, TypeRef> mappings = TypeArguments.getGenericArgumentsMappings(type);
+    return new ClassRefBuilder(supertype)
+        .accept(new ApplyTypeParamMappingToTypeArguments(mappings))
+        .build();
+  }
+}

--- a/model/utils/src/main/java/io/sundr/model/utils/Collections.java
+++ b/model/utils/src/main/java/io/sundr/model/utils/Collections.java
@@ -24,15 +24,18 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import io.sundr.model.ClassRef;
 import io.sundr.model.Kind;
 import io.sundr.model.TypeDef;
 import io.sundr.model.TypeDefBuilder;
 import io.sundr.model.TypeParamDef;
 import io.sundr.model.TypeRef;
 import io.sundr.model.VoidRef;
+import io.sundr.model.functions.TypeCast;
 
 public class Collections {
 
@@ -72,10 +75,14 @@ public class Collections {
       .withExtendsList(ITERABLE.toReference(E.toReference()))
       .build();
 
+  public static final ClassRef COLLECTION_REF = COLLECTION.toReference();
+
   public static final TypeDef MAP = new TypeDefBuilder(TypeDef.forName(Map.class.getName()))
       .withKind(Kind.INTERFACE)
       .withParameters(K, V)
       .build();
+
+  public static final ClassRef MAP_REF = MAP.toReference();
 
   public static final TypeDef MAP_ENTRY = new TypeDefBuilder(TypeDef.forName(Map.Entry.class.getName()))
       .withKind(Kind.INTERFACE)
@@ -170,9 +177,40 @@ public class Collections {
     }
   };
 
+  public static final TypeCast AS_MAP = TypeCast.to(MAP_REF);
+  public static final TypeCast AS_COLLECTION = TypeCast.to(COLLECTION_REF);
+
+  /**
+   * If the supplied type implements {@link java.util.Collection} (directly or indirectly), determine its generic element type.
+   * Otherwise, return {@link Optional#empty()}
+   */
+  public static Optional<TypeRef> getCollectionElementType(TypeRef collectionType) {
+    return extractArgument(collectionType, AS_COLLECTION, 0);
+  }
+
+  /**
+   * If the supplied type implements {@link java.util.Map} (directly or indirectly), determine its generic key type. Otherwise,
+   * return {@link Optional#empty()}
+   */
+  public static Optional<TypeRef> getMapKeyType(TypeRef mapType) {
+    return extractArgument(mapType, AS_MAP, 0);
+  }
+
+  /**
+   * If the supplied type implements {@link java.util.Map} (directly or indirectly), determine its generic value type.
+   * Otherwise, return {@link Optional#empty()}
+   */
+  public static Optional<TypeRef> getMapValueType(TypeRef mapType) {
+    return extractArgument(mapType, AS_MAP, 1);
+  }
+
+  private static Optional<TypeRef> extractArgument(TypeRef type, TypeCast typeCast, int index) {
+    return typeCast.apply(type).map(castType -> castType.getArguments().get(index));
+  }
+
   /**
    * Checks if a {@link TypeRef} is a {@link Collection}.
-   * 
+   *
    * @param type The type to check.
    * @return True if its a Collection.
    */

--- a/model/utils/src/main/java/io/sundr/model/utils/TypeArguments.java
+++ b/model/utils/src/main/java/io/sundr/model/utils/TypeArguments.java
@@ -17,6 +17,15 @@
 
 package io.sundr.model.utils;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import io.sundr.model.AttributeKey;
 import io.sundr.model.ClassRef;
 import io.sundr.model.Method;
@@ -32,13 +41,6 @@ import io.sundr.model.visitors.ApplyTypeParamMappingToMethod;
 import io.sundr.model.visitors.ApplyTypeParamMappingToProperty;
 import io.sundr.model.visitors.ApplyTypeParamMappingToTypeArguments;
 import io.sundr.utils.Predicates;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class TypeArguments {
 
@@ -93,11 +95,41 @@ public class TypeArguments {
         definition.getModifiers(), definition.getAttributes());
   }
 
-  private static TypeDef applyGenericArguments(ClassRef ref) {
+  /**
+   * Given a reference to a generic class, determine a mapping between generic arguments definitions and instantiations.
+   * <p>
+   * For example, given a definition of {@code interface Map<K,V> {...}} and a reference {@code Map<String,Integer>},
+   * the mapping will be {@code {K -> String, V -> Integer}}.
+   * <p>
+   * Raw references, that is, references that do not contain generic arguments (like {@code Map}) are accepted and always return
+   * an empty result.
+   * <p>
+   * However, if the reference does contain generic arguments, their count must be equal to the definition.
+   *
+   * @param ref The class reference to evaluate. The corresponding definition will be loaded using {@link GetDefinition}
+   */
+  public static Map<String, TypeRef> getGenericArgumentsMappings(ClassRef ref) {
+    return getGenericArgumentsMappings(ref, GetDefinition.of(ref));
+  }
+
+  /**
+   * Given a reference to a generic class, determine a mapping between generic arguments definitions and instantiations.
+   * <p>
+   * For example, given a definition of {@code interface Map<K,V> {...}} and a reference {@code Map<String,Integer>},
+   * the mapping will be {@code {K -> String, V -> Integer}}.
+   * <p>
+   * Raw references, that is, references that do not contain generic arguments (like {@code Map}) are accepted and always return
+   * an empty result.
+   * <p>
+   * However, if the reference does contain generic arguments, their count must be equal to the definition.
+   *
+   * @param ref The class reference to evaluate.
+   * @param definition The corresponding definition
+   */
+  public static Map<String, TypeRef> getGenericArgumentsMappings(ClassRef ref, TypeDef definition) {
     List<TypeRef> arguments = ref.getArguments();
-    TypeDef definition = GetDefinition.of(ref);
     if (arguments.isEmpty()) {
-      return definition;
+      return Collections.emptyMap();
     }
 
     List<TypeParamDef> parameters = definition.getParameters();
@@ -112,11 +144,22 @@ public class TypeArguments {
       mappings.put(name, typeRef);
     }
 
-    return new TypeDefBuilder(definition)
-        .accept(new ApplyTypeParamMappingToTypeArguments(mappings))  // existing type arguments must be handled before methods and properties
-        .accept(new ApplyTypeParamMappingToProperty(mappings, ORIGINAL_TYPE_PARAMETER),
-                new ApplyTypeParamMappingToMethod(mappings, ORIGINAL_TYPE_PARAMETER))
-        .build();
+    return mappings;
+  }
+
+  private static TypeDef applyGenericArguments(ClassRef ref) {
+    TypeDef definition = GetDefinition.of(ref);
+    Map<String, TypeRef> mappings = getGenericArgumentsMappings(ref, definition);
+
+    if (mappings.isEmpty()) {
+      return definition;
+    } else {
+      return new TypeDefBuilder(definition)
+          .accept(new ApplyTypeParamMappingToTypeArguments(mappings)) // existing type arguments must be handled before methods and properties
+          .accept(new ApplyTypeParamMappingToProperty(mappings, ORIGINAL_TYPE_PARAMETER),
+              new ApplyTypeParamMappingToMethod(mappings, ORIGINAL_TYPE_PARAMETER))
+          .build();
+    }
   }
 
   private static List<Property> applyToProperties(TypeDef definition) {
@@ -130,7 +173,8 @@ public class TypeArguments {
   private static List<Method> applyToMethods(TypeDef definition) {
     return Stream
         .concat(definition.getMethods().stream(),
-            definition.getExtendsList().stream().filter(INTERNAL_JDK.negate()).flatMap(e -> applyToMethods(applyGenericArguments(e)).stream()))
+            definition.getExtendsList().stream().filter(INTERNAL_JDK.negate())
+                .flatMap(e -> applyToMethods(applyGenericArguments(e)).stream()))
         .filter(Predicates.distinct(m -> m.withErasure().getSignature())).collect(Collectors.toList());
   }
 

--- a/model/utils/src/main/java/io/sundr/model/visitors/ApplyTypeParamMappingToTypeArguments.java
+++ b/model/utils/src/main/java/io/sundr/model/visitors/ApplyTypeParamMappingToTypeArguments.java
@@ -17,6 +17,11 @@
 
 package io.sundr.model.visitors;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import io.sundr.builder.Visitor;
 import io.sundr.model.AttributeKey;
 import io.sundr.model.ClassRef;
@@ -25,14 +30,10 @@ import io.sundr.model.ClassRefFluent;
 import io.sundr.model.TypeParamRef;
 import io.sundr.model.TypeRef;
 import io.sundr.utils.Maps;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class ApplyTypeParamMappingToTypeArguments implements Visitor<ClassRefFluent<?>> {
-  private static final AttributeKey<TypeParamRef> ALREADY_REPLACED_KEY
-          = new AttributeKey<>(ApplyTypeParamMappingToTypeArguments.class.getName() + ".ALREADY_REPLACED", boolean.class);
+  private static final AttributeKey<TypeParamRef> ALREADY_REPLACED_KEY = new AttributeKey<>(
+      ApplyTypeParamMappingToTypeArguments.class.getName() + ".ALREADY_REPLACED", boolean.class);
 
   private final Map<String, TypeRef> mappings;
 
@@ -73,7 +74,7 @@ public class ApplyTypeParamMappingToTypeArguments implements Visitor<ClassRefFlu
    * {@link #visit(ClassRefFluent)}
    *
    * @param mappings
-   *         Type argument replacement mappings
+   *        Type argument replacement mappings
    * @return Mapping with values marked by an attribute
    */
   private static Map<String, TypeRef> markTypeParamRefs(Map<String, TypeRef> mappings) {

--- a/model/utils/src/test/java/io/sundr/model/functions/TypeCastTest.java
+++ b/model/utils/src/test/java/io/sundr/model/functions/TypeCastTest.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+package io.sundr.model.functions;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.sundr.model.ClassRef;
+import io.sundr.model.ClassRefBuilder;
+import io.sundr.model.Kind;
+import io.sundr.model.TypeDef;
+import io.sundr.model.TypeDefBuilder;
+import io.sundr.model.repo.DefinitionRepository;
+import io.sundr.model.utils.Collections;
+import io.sundr.model.utils.Types;
+
+public class TypeCastTest {
+
+  public static final ClassRef STRING_INT_MAP_REF = Collections.MAP.toReference(Types.STRING_REF, Types.INT_REF);
+  public static final ClassRef STRING_INT_HASHMAP_REF = Collections.HASH_MAP.toReference(Types.STRING_REF, Types.INT_REF);
+  public static final ClassRef INT_DOUBLE_MAP_REF = Collections.MAP.toReference(Types.INT_REF, Types.DOUBLE_REF);
+
+  @Before
+  public void setUp() throws Exception {
+    DefinitionRepository.getRepository().register(Collections.MAP);
+    DefinitionRepository.getRepository().register(Collections.LIST);
+    DefinitionRepository.getRepository().register(Collections.HASH_MAP);
+  }
+
+  @Test
+  public void directInstance() {
+    Optional<ClassRef> result = TypeCast.to(Collections.MAP.toReference()).apply(STRING_INT_MAP_REF);
+    assertEquals(Optional.of(STRING_INT_MAP_REF), result);
+  }
+
+  @Test
+  public void noMatch() {
+    Optional<ClassRef> result = TypeCast.to(Collections.LIST.toReference()).apply(STRING_INT_MAP_REF);
+    assertEquals(Optional.empty(), result);
+  }
+
+  @Test
+  public void directExtends() {
+    TypeDef definition = new TypeDefBuilder(TypeDef.forName("com.example.MyMap"))
+        .withExtendsList(STRING_INT_HASHMAP_REF)
+        .build();
+    DefinitionRepository.getRepository().register(definition);
+
+    Optional<ClassRef> result = TypeCast.to(Collections.HASH_MAP.toReference()).apply(definition.toReference());
+    assertEquals(Optional.of(STRING_INT_HASHMAP_REF), result);
+  }
+
+  @Test
+  public void directImplements() {
+    TypeDef definition = new TypeDefBuilder(TypeDef.forName("com.example.MyMap"))
+        .withImplementsList(STRING_INT_MAP_REF)
+        .build();
+    DefinitionRepository.getRepository().register(definition);
+
+    Optional<ClassRef> result = TypeCast.to(Collections.MAP.toReference()).apply(definition.toReference());
+    assertEquals(Optional.of(STRING_INT_MAP_REF), result);
+  }
+
+  @Test
+  public void indirectSupertype() {
+    TypeDef definition = new TypeDefBuilder(TypeDef.forName("com.example.MyMap"))
+        .withExtendsList(STRING_INT_HASHMAP_REF)
+        .build();
+    DefinitionRepository.getRepository().register(definition);
+
+    Optional<ClassRef> result = TypeCast.to(Collections.MAP.toReference()).apply(definition.toReference());
+    assertEquals(Optional.of(STRING_INT_MAP_REF), result);
+  }
+
+  @Test
+  public void multiMap() {
+    TypeDef definition = new TypeDefBuilder(TypeDef.forName("com.example.MyMap"))
+        .withParameters(Collections.K, Collections.V)
+        .withImplementsList(
+            Collections.MAP.toReference(
+                Collections.K.toReference(),
+                Collections.LIST.toReference(Collections.V.toReference())))
+        .build();
+    DefinitionRepository.getRepository().register(definition);
+    ClassRef reference = definition.toReference(Types.STRING_REF, Types.INT_REF);
+
+    Optional<ClassRef> result = TypeCast.to(Collections.MAP.toReference()).apply(reference);
+    assertEquals(Optional.of(Collections.MAP.toReference(
+        Types.STRING_REF,
+        Collections.LIST.toReference(Types.INT_REF))), result);
+  }
+
+  @Test
+  public void multiHashMap() {
+    TypeDef definition = new TypeDefBuilder(TypeDef.forName("com.example.MyMap"))
+        .withParameters(Collections.K, Collections.V)
+        .withExtendsList(
+            Collections.HASH_MAP.toReference(
+                Collections.K.toReference(),
+                Collections.LIST.toReference(Collections.V.toReference())))
+        .build();
+    DefinitionRepository.getRepository().register(definition);
+    ClassRef reference = definition.toReference(Types.STRING_REF, Types.INT_REF);
+
+    Optional<ClassRef> result = TypeCast.to(Collections.MAP.toReference()).apply(reference);
+    assertEquals(Optional.of(Collections.MAP.toReference(
+        Types.STRING_REF,
+        Collections.LIST.toReference(Types.INT_REF))), result);
+  }
+
+  @Test
+  public void inheritsSameInterfaceFromMultipleSources() {
+    TypeDef map1 = new TypeDefBuilder(TypeDef.forName("com.example.MyMap1"))
+        .withKind(Kind.INTERFACE)
+        .withExtendsList(STRING_INT_MAP_REF)
+        .build();
+    TypeDef map2 = new TypeDefBuilder(TypeDef.forName("com.example.MyMap2"))
+        .withKind(Kind.INTERFACE)
+        .withExtendsList(STRING_INT_MAP_REF)
+        .build();
+    TypeDef map = new TypeDefBuilder(TypeDef.forName("com.example.MyMapResult"))
+        .withImplementsList(map1.toReference(), map2.toReference())
+        .build();
+
+    DefinitionRepository.getRepository().register(map1);
+    DefinitionRepository.getRepository().register(map2);
+    DefinitionRepository.getRepository().register(map);
+
+    Optional<ClassRef> result = TypeCast.to(Collections.MAP.toReference()).apply(map.toReference());
+    assertEquals(Optional.of(STRING_INT_MAP_REF), result);
+  }
+
+  @Test
+  public void inheritsSameInterfaceWithDifferentArgumentsFromMultipleSources() {
+    TypeDef map1 = new TypeDefBuilder(TypeDef.forName("com.example.MyMap1"))
+        .withKind(Kind.INTERFACE)
+        .withExtendsList(STRING_INT_MAP_REF)
+        .build();
+    TypeDef map2 = new TypeDefBuilder(TypeDef.forName("com.example.MyMap2"))
+        .withKind(Kind.INTERFACE)
+        .withExtendsList(INT_DOUBLE_MAP_REF)
+        .build();
+    TypeDef map = new TypeDefBuilder(TypeDef.forName("com.example.MyMapResult"))
+        .withImplementsList(map1.toReference(), map2.toReference())
+        .build();
+
+    DefinitionRepository.getRepository().register(map1);
+    DefinitionRepository.getRepository().register(map2);
+    DefinitionRepository.getRepository().register(map);
+
+    IllegalStateException exception = assertThrows(IllegalStateException.class,
+        () -> TypeCast.to(Collections.MAP.toReference()).apply(map.toReference()));
+    assertEquals("Type com.example.MyMapResult extends or implements "
+        + "java.util.Map<?,?> multiple times: "
+        + "[java.util.Map<java.lang.String,java.lang.Integer>, java.util.Map<java.lang.Integer,java.lang.Double>]. "
+        + "This is not legal in Java", exception.getMessage());
+  }
+
+  @Test
+  public void javaLangObjectExtendsItself() {
+    TypeDef object = new TypeDefBuilder(Types.OBJECT)
+        .withExtendsList(Types.OBJECT.toReference())
+        .build();
+
+    DefinitionRepository.getRepository().register(object);
+    // this should not cause stack overflow error
+    TypeCast.to(Collections.MAP.toReference()).apply(object.toReference());
+  }
+
+  @Test
+  public void arraysAreNotSupported() {
+    ClassRef cls = new ClassRef("some.Type", 1, new ArrayList<>(), new HashMap<>());
+    assertThrows(IllegalArgumentException.class, () -> TypeCast.to(cls));
+  }
+
+  @Test
+  public void boundedWildcardsAreNotSupported() {
+    ClassRef cls = new ClassRefBuilder().withFullyQualifiedName("some.Type")
+        .addNewWildcardRefArgument().addToBounds(Collections.MAP.toReference()).endWildcardRefArgument()
+        .build();
+    assertThrows(IllegalArgumentException.class, () -> TypeCast.to(cls));
+  }
+}

--- a/model/utils/src/test/java/io/sundr/model/utils/CollectionsTest.java
+++ b/model/utils/src/test/java/io/sundr/model/utils/CollectionsTest.java
@@ -17,38 +17,124 @@
 
 package io.sundr.model.utils;
 
+import static io.sundr.model.utils.Collections.E;
+import static io.sundr.model.utils.Collections.K;
+import static io.sundr.model.utils.Collections.V;
+import static io.sundr.model.utils.Types.INT_REF;
+import static io.sundr.model.utils.Types.STRING_REF;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import io.sundr.model.ClassRef;
 import io.sundr.model.ClassRefBuilder;
 import io.sundr.model.TypeDef;
 import io.sundr.model.TypeDefBuilder;
+import io.sundr.model.TypeParamRef;
+import io.sundr.model.TypeRef;
 import io.sundr.model.repo.DefinitionRepository;
 
 public class CollectionsTest {
+  public static final TypeParamRef E_REF = E.toReference();
 
-  public static final TypeDef LIST = TypeDef.forName(List.class.getName());
+  public static final TypeDef COLLECTION = new TypeDefBuilder(TypeDef.forName(Collection.class.getName()))
+      .addToParameters(E).build();
+  public static final TypeDef LIST = new TypeDefBuilder(TypeDef.forName(List.class.getName()))
+      .withImplementsList(COLLECTION.toInternalReference())
+      .addToParameters(E).build();
   public static final TypeDef ARRAY_LIST = new TypeDefBuilder(TypeDef.forName(ArrayList.class.getName()))
-      .withImplementsList(LIST.toInternalReference()).build();
+      .withImplementsList(LIST.toInternalReference())
+      .addToParameters(E).build();
   public static final TypeDef LINKED_LIST = new TypeDefBuilder(TypeDef.forName(LinkedList.class.getName()))
-      .withImplementsList(LIST.toInternalReference()).build();
-  public static final TypeDef MAP = TypeDef.forName(Map.class.getName());
+      .withImplementsList(LIST.toInternalReference())
+      .addToParameters(E).build();
+  public static final TypeDef CUSTOM_STRING_LIST = new TypeDefBuilder(TypeDef.forName("example.CustomStringList"))
+      .withImplementsList(LIST.toReference(STRING_REF))
+      .build();
+  public static final TypeDef CUSTOM_STRING_ARRAY_LIST = new TypeDefBuilder(TypeDef.forName("example.CustomStringArrayList"))
+      .withExtendsList(ARRAY_LIST.toReference(STRING_REF))
+      .build();
 
-  @Test
-  public void testCollections() throws Exception {
+  public static final TypeDef MAP = new TypeDefBuilder(TypeDef.forName(Map.class.getName()))
+      .addToParameters(K, V).build();
+  public static final TypeDef HASH_MAP = new TypeDefBuilder(TypeDef.forName(HashMap.class.getName()))
+      .withImplementsList(MAP.toInternalReference())
+      .addToParameters(K, V).build();
+  public static final TypeDef TREE_MAP = new TypeDefBuilder(TypeDef.forName(TreeMap.class.getName()))
+      .withImplementsList(MAP.toInternalReference())
+      .addToParameters(K, V).build();
+  public static final TypeDef CUSTOM_STRING_KEYED_MAP = new TypeDefBuilder(TypeDef.forName("example.CustomStringKeyedMap"))
+      .withImplementsList(MAP.toReference(STRING_REF, E_REF))
+      .addToParameters(E)
+      .build();
+  public static final TypeDef CUSTOM_INTEGER_VALUED_MAP = new TypeDefBuilder(TypeDef.forName("example.CustomIntegerValuedMap"))
+      .withImplementsList(MAP.toReference(E_REF, INT_REF))
+      .addToParameters(E)
+      .build();
+  public static final TypeDef CUSTOM_STRING_INTEGER_MAP = new TypeDefBuilder(TypeDef.forName("example.CustomStringIntegerMap"))
+      .withImplementsList(MAP.toReference(STRING_REF, INT_REF))
+      .build();
+  public static final TypeDef CUSTOM_STRING_KEYED_HASH_MAP = new TypeDefBuilder(
+      TypeDef.forName("example.CustomStringKeyedHashMap"))
+          .withExtendsList(HASH_MAP.toReference(STRING_REF, E_REF))
+          .addToParameters(E)
+          .build();
+  public static final TypeDef CUSTOM_INTEGER_VALUED_HASH_MAP = new TypeDefBuilder(
+      TypeDef.forName("example.CustomIntegerValuedHashMap"))
+          .withExtendsList(HASH_MAP.toReference(E_REF, INT_REF))
+          .addToParameters(E)
+          .build();
+  public static final TypeDef CUSTOM_STRING_INTEGER_HASH_MAP = new TypeDefBuilder(
+      TypeDef.forName("example.CustomStringIntegerHashMap"))
+          .withExtendsList(HASH_MAP.toReference(STRING_REF, INT_REF))
+          .build();
+
+  public static final TypeDef MULTI_MAP = new TypeDefBuilder(TypeDef.forName("example.MultiMap"))
+      .addToParameters(K, V)
+      .withImplementsList(MAP.toReference(K.toReference(), LIST.toReference(V.toReference())))
+      .build();
+  public static final TypeDef MULTI_HASH_MAP = new TypeDefBuilder(TypeDef.forName("example.MultiHashMap"))
+      .addToParameters(K, V)
+      .withExtendsList(HASH_MAP.toReference(K.toReference(), LIST.toReference(V.toReference())))
+      .build();
+
+  @Before
+  public void setUp() {
+    DefinitionRepository.getRepository().register(COLLECTION);
     DefinitionRepository.getRepository().register(LIST);
     DefinitionRepository.getRepository().register(ARRAY_LIST);
     DefinitionRepository.getRepository().register(LINKED_LIST);
-    DefinitionRepository.getRepository().register(MAP);
+    DefinitionRepository.getRepository().register(CUSTOM_STRING_LIST);
+    DefinitionRepository.getRepository().register(CUSTOM_STRING_ARRAY_LIST);
 
+    DefinitionRepository.getRepository().register(MAP);
+    DefinitionRepository.getRepository().register(HASH_MAP);
+    DefinitionRepository.getRepository().register(TREE_MAP);
+    DefinitionRepository.getRepository().register(CUSTOM_STRING_KEYED_MAP);
+    DefinitionRepository.getRepository().register(CUSTOM_INTEGER_VALUED_MAP);
+    DefinitionRepository.getRepository().register(CUSTOM_STRING_INTEGER_MAP);
+    DefinitionRepository.getRepository().register(CUSTOM_STRING_KEYED_HASH_MAP);
+    DefinitionRepository.getRepository().register(CUSTOM_INTEGER_VALUED_HASH_MAP);
+    DefinitionRepository.getRepository().register(CUSTOM_STRING_INTEGER_HASH_MAP);
+
+    DefinitionRepository.getRepository().register(MULTI_MAP);
+    DefinitionRepository.getRepository().register(MULTI_HASH_MAP);
+  }
+
+  @Test
+  public void testCollections() throws Exception {
     ClassRef list = new ClassRefBuilder()
         .withFullyQualifiedName("java.util.List")
         .build();
@@ -93,5 +179,64 @@ public class CollectionsTest {
     assertTrue(Collections.IS_LIST.apply(linkedList));
     assertTrue(Collections.IS_LIST.apply(linkedListOfString));
     assertFalse(Collections.IS_LIST.apply(map));
+  }
+
+  @Test
+  public void listElementTypeIsDetermined() {
+    final Optional<TypeRef> STRING_RESULT = Optional.of(STRING_REF);
+    assertEquals(STRING_RESULT, Collections.getCollectionElementType(COLLECTION.toReference(STRING_REF)));
+    assertEquals(STRING_RESULT, Collections.getCollectionElementType(LIST.toReference(STRING_REF)));
+    assertEquals(STRING_RESULT, Collections.getCollectionElementType(ARRAY_LIST.toReference(STRING_REF)));
+    assertEquals(STRING_RESULT, Collections.getCollectionElementType(LINKED_LIST.toReference(STRING_REF)));
+    assertEquals(STRING_RESULT, Collections.getCollectionElementType(CUSTOM_STRING_LIST.toReference()));
+    assertEquals(STRING_RESULT, Collections.getCollectionElementType(CUSTOM_STRING_ARRAY_LIST.toReference()));
+
+    assertEquals(Optional.empty(), Collections.getCollectionElementType(MAP.toReference(STRING_REF, STRING_REF)));
+  }
+
+  @Test
+  public void mapKeyTypeIsDetermined() {
+    final Optional<TypeRef> STRING_RESULT = Optional.of(STRING_REF);
+    assertEquals(STRING_RESULT, Collections.getMapKeyType(MAP.toReference(STRING_REF, INT_REF)));
+    assertEquals(STRING_RESULT, Collections.getMapKeyType(HASH_MAP.toReference(STRING_REF, INT_REF)));
+    assertEquals(STRING_RESULT, Collections.getMapKeyType(TREE_MAP.toReference(STRING_REF, INT_REF)));
+    assertEquals(STRING_RESULT, Collections.getMapKeyType(CUSTOM_STRING_KEYED_MAP.toReference(INT_REF)));
+    assertEquals(STRING_RESULT, Collections.getMapKeyType(CUSTOM_INTEGER_VALUED_MAP.toReference(STRING_REF)));
+    assertEquals(STRING_RESULT, Collections.getMapKeyType(CUSTOM_STRING_INTEGER_MAP.toReference()));
+    assertEquals(STRING_RESULT, Collections.getMapKeyType(CUSTOM_STRING_KEYED_HASH_MAP.toReference(INT_REF)));
+    assertEquals(STRING_RESULT, Collections.getMapKeyType(CUSTOM_INTEGER_VALUED_HASH_MAP.toReference(STRING_REF)));
+    assertEquals(STRING_RESULT, Collections.getMapKeyType(CUSTOM_STRING_INTEGER_HASH_MAP.toReference()));
+
+    assertEquals(Optional.empty(), Collections.getMapKeyType(COLLECTION.toReference(STRING_REF)));
+  }
+
+  @Test
+  public void mapValueTypeIsDetermined() {
+    final Optional<TypeRef> INT_RESULT = Optional.of(INT_REF);
+    assertEquals(INT_RESULT, Collections.getMapValueType(MAP.toReference(STRING_REF, INT_REF)));
+    assertEquals(INT_RESULT, Collections.getMapValueType(HASH_MAP.toReference(STRING_REF, INT_REF)));
+    assertEquals(INT_RESULT, Collections.getMapValueType(TREE_MAP.toReference(STRING_REF, INT_REF)));
+    assertEquals(INT_RESULT, Collections.getMapValueType(CUSTOM_STRING_KEYED_MAP.toReference(INT_REF)));
+    assertEquals(INT_RESULT, Collections.getMapValueType(CUSTOM_INTEGER_VALUED_MAP.toReference(STRING_REF)));
+    assertEquals(INT_RESULT, Collections.getMapValueType(CUSTOM_STRING_INTEGER_MAP.toReference()));
+    assertEquals(INT_RESULT, Collections.getMapValueType(CUSTOM_STRING_KEYED_HASH_MAP.toReference(INT_REF)));
+    assertEquals(INT_RESULT, Collections.getMapValueType(CUSTOM_INTEGER_VALUED_HASH_MAP.toReference(STRING_REF)));
+    assertEquals(INT_RESULT, Collections.getMapValueType(CUSTOM_STRING_INTEGER_HASH_MAP.toReference()));
+
+    assertEquals(Optional.empty(), Collections.getMapValueType(COLLECTION.toReference(STRING_REF)));
+  }
+
+  @Test
+  public void mapKeyAndValueTypesAreDeterminedForMultiMaps() {
+    final Optional<TypeRef> STRING_RESULT = Optional.of(STRING_REF);
+    final Optional<TypeRef> LIST_OF_INT_RESULT = Optional.of(LIST.toReference(INT_REF));
+
+    ClassRef STRING_INT_MULTI_MAP_REF = MULTI_MAP.toReference(STRING_REF, INT_REF);
+    assertEquals(STRING_RESULT, Collections.getMapKeyType(STRING_INT_MULTI_MAP_REF));
+    assertEquals(LIST_OF_INT_RESULT, Collections.getMapValueType(STRING_INT_MULTI_MAP_REF));
+
+    ClassRef STRING_INT_MULTI_HASH_MAP_REF = MULTI_HASH_MAP.toReference(STRING_REF, INT_REF);
+    assertEquals(STRING_RESULT, Collections.getMapKeyType(STRING_INT_MULTI_HASH_MAP_REF));
+    assertEquals(LIST_OF_INT_RESULT, Collections.getMapValueType(STRING_INT_MULTI_HASH_MAP_REF));
   }
 }

--- a/model/utils/src/test/java/io/sundr/model/utils/TypeArgumentsTest.java
+++ b/model/utils/src/test/java/io/sundr/model/utils/TypeArgumentsTest.java
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
 package io.sundr.model.utils;
 
 import static io.sundr.model.utils.Collections.E;
@@ -7,9 +24,19 @@ import static io.sundr.model.utils.Types.OPTIONAL;
 import static io.sundr.model.utils.Types.STRING_REF;
 import static io.sundr.model.utils.Types.VOID;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import io.sundr.builder.Visitor;
 import io.sundr.model.ClassRef;
+import io.sundr.model.ClassRefBuilder;
 import io.sundr.model.Kind;
 import io.sundr.model.Method;
 import io.sundr.model.Property;
@@ -17,145 +44,195 @@ import io.sundr.model.RichTypeDef;
 import io.sundr.model.TypeDef;
 import io.sundr.model.TypeDefBuilder;
 import io.sundr.model.TypeRef;
+import io.sundr.model.WildcardRef;
 import io.sundr.model.functions.GetDefinition;
 import io.sundr.model.repo.DefinitionRepository;
 import io.sundr.utils.Strings;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
 
-// Credits to: Dusan Jakub (xRodney).
 public class TypeArgumentsTest {
 
-    public static final TypeDef MULTI_HASH_MAP = new TypeDefBuilder(TypeDef.forName("com.example.MultiHashMap"))
-            .withKind(Kind.CLASS).withParameters(K, V)
-            .withExtendsList(
-                    Collections.HASH_MAP.toReference(K.toReference(), Collections.LIST.toReference(V.toReference())))
-            .build();
+  public static final TypeDef MULTI_HASH_MAP = new TypeDefBuilder(TypeDef.forName("com.example.MultiHashMap"))
+      .withKind(Kind.CLASS).withParameters(K, V)
+      .withExtendsList(
+          Collections.HASH_MAP.toReference(K.toReference(), Collections.LIST.toReference(V.toReference())))
+      .build();
 
-    public static final TypeDef MY_SUPERCLASS = new TypeDefBuilder(TypeDef.forName("com.example.MySuperclass"))
-            .withKind(Kind.CLASS).withParameters(E)
-            .accept(addBackedProperty(E.toReference(), "superValue"))
-            .accept(addBackedProperty(Collections.LIST.toReference(E.toReference()), "superValues"))
-            .build();
+  public static final TypeDef MY_SUPERCLASS = new TypeDefBuilder(TypeDef.forName("com.example.MySuperclass"))
+      .withKind(Kind.CLASS).withParameters(E)
+      .accept(addBackedProperty(E.toReference(), "superValue"))
+      .accept(addBackedProperty(Collections.LIST.toReference(E.toReference()), "superValues"))
+      .build();
 
-    public static final TypeDef MY_SUBCLASS = new TypeDefBuilder(TypeDef.forName("com.example.MySubclass"))
-            .withKind(Kind.CLASS).withParameters(E)
-            .accept(addBackedProperty(E.toReference(), "subValue"))
-            .accept(addBackedProperty(Collections.LIST.toReference(E.toReference()), "subValues"))
-            .withExtendsList(MY_SUPERCLASS.toReference(OPTIONAL.toReference(E.toReference())))
-            .build();
+  public static final TypeDef MY_SUBCLASS = new TypeDefBuilder(TypeDef.forName("com.example.MySubclass"))
+      .withKind(Kind.CLASS).withParameters(E)
+      .accept(addBackedProperty(E.toReference(), "subValue"))
+      .accept(addBackedProperty(Collections.LIST.toReference(E.toReference()), "subValues"))
+      .withExtendsList(MY_SUPERCLASS.toReference(OPTIONAL.toReference(E.toReference())))
+      .build();
 
-    @Before
-    public void setUp() {
-        DefinitionRepository.getRepository().register(Collections.MAP);
-        DefinitionRepository.getRepository().register(Collections.HASH_MAP);
-        DefinitionRepository.getRepository().register(Collections.LIST);
-        DefinitionRepository.getRepository().register(Types.STRING);
-        DefinitionRepository.getRepository().register(Types.INT);
-        DefinitionRepository.getRepository().register(MULTI_HASH_MAP);
-        DefinitionRepository.getRepository().register(MY_SUBCLASS);
-        DefinitionRepository.getRepository().register(MY_SUPERCLASS);
-    }
+  @Before
+  public void setUp() {
+    DefinitionRepository.getRepository().register(Collections.MAP);
+    DefinitionRepository.getRepository().register(Collections.HASH_MAP);
+    DefinitionRepository.getRepository().register(Collections.LIST);
+    DefinitionRepository.getRepository().register(Types.STRING);
+    DefinitionRepository.getRepository().register(Types.INT);
+    DefinitionRepository.getRepository().register(MULTI_HASH_MAP);
+    DefinitionRepository.getRepository().register(MY_SUBCLASS);
+    DefinitionRepository.getRepository().register(MY_SUPERCLASS);
+  }
 
-    @Test
-    public void shouldNotCauseStackOverflow() {
-        ClassRef classRef = MULTI_HASH_MAP.toReference(Types.STRING_REF, Types.INT_REF);
-        TypeDef typeDef = GetDefinition.of(classRef);
-        RichTypeDef richDef = TypeArguments.apply(GetDefinition.of(classRef));
+  @Test
+  public void shouldNotCauseStackOverflow() {
+    ClassRef classRef = MULTI_HASH_MAP.toReference(Types.STRING_REF, Types.INT_REF);
+    TypeDef typeDef = GetDefinition.of(classRef);
+    RichTypeDef richDef = TypeArguments.apply(GetDefinition.of(classRef));
 
-        System.out.println(typeDef.render());
-        System.out.println(richDef.render());
+    System.out.println(typeDef.render());
+    System.out.println(richDef.render());
 
-        // This goes beyond the purpose of the tests, which is to check against SO.
-        // Still, it's nice to know that the rendered code is not affected (for THIS scenario).
-        assertEquals(typeDef.render(), richDef.render());
-    }
+    // This goes beyond the purpose of the tests, which is to check against SO.
+    // Still, it's nice to know that the rendered code is not affected (for THIS scenario).
+    assertEquals(typeDef.render(), richDef.render());
+  }
 
-    @Test
-    public void propertiesAndMethodsFromSupertypesAreResolvedCorrectlyOnTypeDefinition() {
-        ClassRef classRef = MY_SUBCLASS.toReference();
-        TypeDef typeDef = GetDefinition.of(classRef);
-        RichTypeDef richDef = TypeArguments.apply(GetDefinition.of(classRef));
+  @Test
+  public void propertiesAndMethodsFromSupertypesAreResolvedCorrectlyOnTypeDefinition() {
+    ClassRef classRef = MY_SUBCLASS.toReference();
+    TypeDef typeDef = GetDefinition.of(classRef);
+    RichTypeDef richDef = TypeArguments.apply(GetDefinition.of(classRef));
 
-        System.out.println(typeDef.render());
-        System.out.println(richDef.render());
+    System.out.println(typeDef.render());
+    System.out.println(richDef.render());
 
-        Map<String, Property> propertiesByName = richDef.getAllProperties().stream()
-                .collect(Collectors.toMap(Property::getName, Function.identity()));
-        assertEquals(4, propertiesByName.size());
-        assertEquals("E subValue", propertiesByName.get("subValue").render());
-        assertEquals("java.util.List<E> subValues", propertiesByName.get("subValues").render());
-        assertEquals("java.util.Optional<E> superValue", propertiesByName.get("superValue").render());
-        assertEquals("java.util.List<java.util.Optional<E>> superValues", propertiesByName.get("superValues").render());
+    Map<String, Property> propertiesByName = richDef.getAllProperties().stream()
+        .collect(Collectors.toMap(Property::getName, Function.identity()));
+    assertEquals(4, propertiesByName.size());
+    assertEquals("E subValue", propertiesByName.get("subValue").render());
+    assertEquals("java.util.List<E> subValues", propertiesByName.get("subValues").render());
+    assertEquals("java.util.Optional<E> superValue", propertiesByName.get("superValue").render());
+    assertEquals("java.util.List<java.util.Optional<E>> superValues", propertiesByName.get("superValues").render());
 
-        Map<String, Method> methodsByName = richDef.getAllMethods().stream()
-                .collect(Collectors.toMap(Method::getName, Function.identity()));
-        assertEquals(8, methodsByName.size());
+    Map<String, Method> methodsByName = richDef.getAllMethods().stream()
+        .collect(Collectors.toMap(Method::getName, Function.identity()));
+    assertEquals(8, methodsByName.size());
 
-        assertEquals("E getSubValue();", methodsByName.get("getSubValue").render());
-        assertEquals("void setSubValue(E subValue);", methodsByName.get("setSubValue").render());
-        assertEquals("java.util.List<E> getSubValues();", methodsByName.get("getSubValues").render());
-        assertEquals("void setSubValues(java.util.List<E> subValues);", methodsByName.get("setSubValues").render());
+    assertEquals("E getSubValue();", methodsByName.get("getSubValue").render());
+    assertEquals("void setSubValue(E subValue);", methodsByName.get("setSubValue").render());
+    assertEquals("java.util.List<E> getSubValues();", methodsByName.get("getSubValues").render());
+    assertEquals("void setSubValues(java.util.List<E> subValues);", methodsByName.get("setSubValues").render());
 
-        assertEquals("java.util.Optional<E> getSuperValue();", methodsByName.get("getSuperValue").render());
-        assertEquals("void setSuperValue(java.util.Optional<E> superValue);",
-                methodsByName.get("setSuperValue").render());
-        assertEquals("java.util.List<java.util.Optional<E>> getSuperValues();",
-                methodsByName.get("getSuperValues").render());
-        assertEquals("void setSuperValues(java.util.List<java.util.Optional<E>> superValues);",
-                methodsByName.get("setSuperValues").render());
-    }
+    assertEquals("java.util.Optional<E> getSuperValue();", methodsByName.get("getSuperValue").render());
+    assertEquals("void setSuperValue(java.util.Optional<E> superValue);",
+        methodsByName.get("setSuperValue").render());
+    assertEquals("java.util.List<java.util.Optional<E>> getSuperValues();",
+        methodsByName.get("getSuperValues").render());
+    assertEquals("void setSuperValues(java.util.List<java.util.Optional<E>> superValues);",
+        methodsByName.get("setSuperValues").render());
+  }
 
-    @Test
-    public void propertiesAndMethodsFromSupertypesAreResolvedCorrectlyOnTypeReference() {
-        ClassRef classRef = MY_SUBCLASS.toReference(STRING_REF);
-        RichTypeDef richDef = TypeArguments.apply(classRef);
+  @Test
+  public void propertiesAndMethodsFromSupertypesAreResolvedCorrectlyOnTypeReference() {
+    ClassRef classRef = MY_SUBCLASS.toReference(STRING_REF);
+    RichTypeDef richDef = TypeArguments.apply(classRef);
 
-        System.out.println(richDef.render());
+    System.out.println(richDef.render());
 
-        Map<String, Property> propertiesByName = richDef.getAllProperties().stream()
-                .collect(Collectors.toMap(Property::getName, Function.identity()));
-        assertEquals(4, propertiesByName.size());
-        assertEquals("java.lang.String subValue", propertiesByName.get("subValue").render());
-        assertEquals("java.util.List<java.lang.String> subValues", propertiesByName.get("subValues").render());
-        assertEquals("java.util.Optional<java.lang.String> superValue", propertiesByName.get("superValue").render());
-        assertEquals("java.util.List<java.util.Optional<java.lang.String>> superValues", propertiesByName.get("superValues").render());
+    Map<String, Property> propertiesByName = richDef.getAllProperties().stream()
+        .collect(Collectors.toMap(Property::getName, Function.identity()));
+    assertEquals(4, propertiesByName.size());
+    assertEquals("java.lang.String subValue", propertiesByName.get("subValue").render());
+    assertEquals("java.util.List<java.lang.String> subValues", propertiesByName.get("subValues").render());
+    assertEquals("java.util.Optional<java.lang.String> superValue", propertiesByName.get("superValue").render());
+    assertEquals("java.util.List<java.util.Optional<java.lang.String>> superValues",
+        propertiesByName.get("superValues").render());
 
-        Map<String, Method> methodsByName = richDef.getAllMethods().stream()
-                .collect(Collectors.toMap(Method::getName, Function.identity()));
-        assertEquals(8, methodsByName.size());
+    Map<String, Method> methodsByName = richDef.getAllMethods().stream()
+        .collect(Collectors.toMap(Method::getName, Function.identity()));
+    assertEquals(8, methodsByName.size());
 
-        assertEquals("java.lang.String getSubValue();", methodsByName.get("getSubValue").render());
-        assertEquals("void setSubValue(java.lang.String subValue);", methodsByName.get("setSubValue").render());
-        assertEquals("java.util.List<java.lang.String> getSubValues();", methodsByName.get("getSubValues").render());
-        assertEquals("void setSubValues(java.util.List<java.lang.String> subValues);", methodsByName.get("setSubValues").render());
+    assertEquals("java.lang.String getSubValue();", methodsByName.get("getSubValue").render());
+    assertEquals("void setSubValue(java.lang.String subValue);", methodsByName.get("setSubValue").render());
+    assertEquals("java.util.List<java.lang.String> getSubValues();", methodsByName.get("getSubValues").render());
+    assertEquals("void setSubValues(java.util.List<java.lang.String> subValues);", methodsByName.get("setSubValues").render());
 
-        assertEquals("java.util.Optional<java.lang.String> getSuperValue();", methodsByName.get("getSuperValue").render());
-        assertEquals("void setSuperValue(java.util.Optional<java.lang.String> superValue);",
-                methodsByName.get("setSuperValue").render());
-        assertEquals("java.util.List<java.util.Optional<java.lang.String>> getSuperValues();",
-                methodsByName.get("getSuperValues").render());
-        assertEquals("void setSuperValues(java.util.List<java.util.Optional<java.lang.String>> superValues);",
-                methodsByName.get("setSuperValues").render());
-    }
+    assertEquals("java.util.Optional<java.lang.String> getSuperValue();", methodsByName.get("getSuperValue").render());
+    assertEquals("void setSuperValue(java.util.Optional<java.lang.String> superValue);",
+        methodsByName.get("setSuperValue").render());
+    assertEquals("java.util.List<java.util.Optional<java.lang.String>> getSuperValues();",
+        methodsByName.get("getSuperValues").render());
+    assertEquals("void setSuperValues(java.util.List<java.util.Optional<java.lang.String>> superValues);",
+        methodsByName.get("setSuperValues").render());
+  }
 
-    /**
-     * Register a field with a type and name, and corresponding getter and setter methods
-     */
-    private static Visitor<TypeDefBuilder> addBackedProperty(TypeRef type, String name) {
-        return new Visitor<TypeDefBuilder>() {
-            @Override
-            public void visit(TypeDefBuilder typeDef) {
-                typeDef.addNewProperty().withName(name).withTypeRef(type).endProperty()
+  /**
+   * Register a field with a type and name, and corresponding getter and setter methods
+   */
+  private static Visitor<TypeDefBuilder> addBackedProperty(TypeRef type, String name) {
+    return new Visitor<TypeDefBuilder>() {
+      @Override
+      public void visit(TypeDefBuilder typeDef) {
+        typeDef.addNewProperty().withName(name).withTypeRef(type).endProperty()
 
-                        .addNewMethod().withName("get" + Strings.capitalizeFirst(name)).withReturnType(type).endMethod()
+            .addNewMethod().withName("get" + Strings.capitalizeFirst(name)).withReturnType(type).endMethod()
 
-                        .addNewMethod().withName("set" + Strings.capitalizeFirst(name)).withVoidRefReturnType(VOID)
-                        .addNewArgument().withTypeRef(type).withName(name).endArgument().endMethod();
-            }
-        };
-    }
+            .addNewMethod().withName("set" + Strings.capitalizeFirst(name)).withVoidRefReturnType(VOID)
+            .addNewArgument().withTypeRef(type).withName(name).endArgument().endMethod();
+      }
+    };
+  }
+
+  @Test
+  public void getGenericArgumentsMappingsShouldCorrectlyDetermineMappings() {
+    ClassRef ref = Collections.MAP.toReference(Types.STRING_REF, Types.INT_REF);
+    Map<String, TypeRef> map = TypeArguments.getGenericArgumentsMappings(ref);
+    assertEquals(Types.STRING_REF, map.get("K"));
+    assertEquals(Types.INT_REF, map.get("V"));
+    assertEquals(2, map.size());
+  }
+
+  @Test
+  public void getGenericArgumentsMappingsShouldHandleWildcards() {
+    ClassRef ref = Collections.MAP.toReference();
+    Map<String, TypeRef> map = TypeArguments.getGenericArgumentsMappings(ref);
+    assertTrue(map.get("K") + " instanceof WildcardRef", map.get("K") instanceof WildcardRef);
+    assertTrue(map.get("V") + " instanceof WildcardRef", map.get("V") instanceof WildcardRef);
+    assertEquals(2, map.size());
+  }
+
+  @Test
+  public void getGenericArgumentsMappingsShouldHandleRawReferences() {
+    ClassRef ref = ClassRef.forName(Collections.MAP.getFullyQualifiedName());
+    Map<String, TypeRef> map = TypeArguments.getGenericArgumentsMappings(ref);
+    assertTrue(map.isEmpty());
+  }
+
+  @Test
+  public void getGenericArgumentsMappingsShouldHandleComplexTypes() {
+    TypeRef key = K.toReference();
+    TypeRef value = Collections.LIST.toReference(V.toReference());
+    ClassRef ref = Collections.MAP.toReference(key, value);
+    Map<String, TypeRef> map = TypeArguments.getGenericArgumentsMappings(ref);
+    assertEquals(key, map.get("K"));
+    assertEquals(value, map.get("V"));
+    assertEquals(2, map.size());
+  }
+
+  @Test
+  public void getGenericArgumentsMappingsShouldErrorIfTooFewArguments() {
+    ClassRef tooFew = new ClassRefBuilder(Collections.MAP.toReference())
+        .withArguments(K.toReference()).build();
+    IllegalStateException exception = assertThrows(IllegalStateException.class,
+        () -> TypeArguments.getGenericArgumentsMappings(tooFew));
+    assertEquals("Incompatible reference java.util.Map<K> to public interface Map<K,V>", exception.getMessage());
+  }
+
+  @Test
+  public void getGenericArgumentsMappingsShouldErrorIfTooManyArguments() {
+    ClassRef tooMany = new ClassRefBuilder(Collections.MAP.toReference())
+        .withArguments(K.toReference(), K.toReference(), K.toReference()).build();
+    IllegalStateException exception = assertThrows(IllegalStateException.class,
+        () -> TypeArguments.getGenericArgumentsMappings(tooMany));
+    assertEquals("Incompatible reference java.util.Map<K,K,K> to public interface Map<K,V>", exception.getMessage());
+  }
 }


### PR DESCRIPTION
Fixes #341

This PR adds a new reusable routine `TypeCast`, which is used to investigate type relations with respect to generic arguments (like improved `isInstanceOf`).

`TypeCast` is then used by three new utility methods to `Collections`: `getCollectionElementType`, `getMapKeyType` and `getMapValueType`. These are similar to `TypeAs.UNWRAP_MAP_VALUE_OF` & friends, but return `Optional.empty()` when the supplied type is not a Collection / Map (as opposed to the supplied type itself). In fact, the `UNWRAP_*` functions now delegate to `Collections` and therefore now return more accurate results.

Last but not least, I have identified a new public routine `TypeArguments.getGenericArgumentsMappings(ClassRef ref, TypeDef definition)`. This creates a mapping from generic types on a TypeDef to their instantiation on ClassRef. This code has been used at multiple places both in sundrio, but also in kubernetes-client. So I think it deserves a common implementation.