### PR TITLE
improve: avoid using streams in the hot path

### DIFF
--- a/core/src/main/java/io/sundr/builder/BaseFluent.java
+++ b/core/src/main/java/io/sundr/builder/BaseFluent.java
@@ -104,12 +104,11 @@ public class BaseFluent<F extends Fluent<F>> implements Fluent<F>, Visitable<F> 
     List<Entry<String, Object>> copyOfPath = path != null ? new ArrayList(path) : new ArrayList<>();
     copyOfPath.add(new AbstractMap.SimpleEntry<>(currentKey, this));
 
-    for (Entry<String, List<Visitable>> entry : _visitables.entrySet()) {
+    for (Entry<String, ?> entry : _visitables.entrySet()) {
       List<Entry<String, Object>> newPath = Collections.unmodifiableList(copyOfPath);
-      // Copy visitables to avoid ConcurrrentModificationException when Visitors add/remove Visitables
 
-      for (Visitable visitable : new ArrayList<>(entry.getValue())) {
-
+      // Copy visitables to avoid ConcurrentModificationException when Visitors add/remove Visitables
+      for (Visitable<F> visitable : new ArrayList<>((List<Visitable<F>>) entry.getValue())) {
         for (Visitor visitor : visitors) {
           if (visitor.getType() != null && visitor.getType().isAssignableFrom(visitable.getClass())) {
             visitable.accept(newPath, entry.getKey(), visitor);

--- a/core/src/main/java/io/sundr/builder/VisitorWiretap.java
+++ b/core/src/main/java/io/sundr/builder/VisitorWiretap.java
@@ -48,7 +48,10 @@ public class VisitorWiretap<T> implements Visitor<T> {
   @Override
   public <F> Boolean canVisit(List<Entry<String, Object>> path, F target) {
     boolean canVisit = delegate.canVisit(path, target);
-    listeners.forEach(l -> l.onCheck(delegate, canVisit, target));
+    for (VisitorListener l : listeners) {
+      l.onCheck(delegate, canVisit, target);
+    }
+
     return canVisit;
   }
 
@@ -59,16 +62,24 @@ public class VisitorWiretap<T> implements Visitor<T> {
 
   @Override
   public void visit(T target) {
-    listeners.forEach(l -> l.beforeVisit(delegate, Collections.emptyList(), target));
+    for (VisitorListener l : listeners) {
+      l.beforeVisit(delegate, Collections.emptyList(), target);
+    }
     delegate.visit(target);
-    listeners.forEach(l -> l.afterVisit(delegate, Collections.emptyList(), target));
+    for (VisitorListener l : listeners) {
+      l.afterVisit(delegate, Collections.emptyList(), target);
+    }
   }
 
   @Override
   public void visit(List<Entry<String, Object>> path, T target) {
-    listeners.forEach(l -> l.beforeVisit(delegate, path, target));
+    for (VisitorListener l : listeners) {
+      l.beforeVisit(delegate, path, target);
+    }
     delegate.visit(path, target);
-    listeners.forEach(l -> l.afterVisit(delegate, path, target));
+    for (VisitorListener l : listeners) {
+      l.afterVisit(delegate, path, target);
+    }
   }
 
   @Override


### PR DESCRIPTION
I've a k8s operator and I generate the CRDs using the fabric8 client. 
Doing a CPU flamegraph it's pretty clear that the overhead added by the usage of java streams in the hot path is relevant. 

I've modified the `BaseFluent#visit` and `VisitorWrap` main methods to use old plain for-loops.
In my project I have thousands of crd properties and the conversion is performed in ~80 seconds. 
With these improvements I'm able to save ~15 seconds