### PR TITLE
Add maven.clean.skip=true to generate BOM

### DIFF
--- a/maven-plugin/src/main/java/io/sundr/maven/GenerateBomMojo.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/GenerateBomMojo.java
@@ -373,7 +373,8 @@ public class GenerateBomMojo extends AbstractSundrioMojo {
     toBuild.getModel().setProfiles(project.getModel().getProfiles());
 
     //We want to avoid having the generated stuff wiped.
-    toBuild.getProperties().put("clean.skip", "true");
+    toBuild.getProperties().put("clean.skip", "true");  // for maven clean 2.x
+    toBuild.getProperties().put("maven.clean.skip", "true"); // for maven clean 3.x
     toBuild.getModel().getBuild().setDirectory(bomDir.getAbsolutePath());
     toBuild.getModel().getBuild().setOutputDirectory(new File(bomDir, "target").getAbsolutePath());
     for (String key : config.getProperties().stringPropertyNames()) {


### PR DESCRIPTION
The property used to skip the clean was renamed to `maven.clean.skip` in the clean plugin 3.x. This just set both properties to support each version.

Check: https://maven.apache.org/plugins/maven-clean-plugin/clean-mojo.html#skip