### PR TITLE
Limit the use of TypeDef in favor of ClassRef in the builder module.

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/Constants.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/Constants.java
@@ -45,8 +45,7 @@ public class Constants {
   public static final String DEFAULT_BUILDER_PACKAGE = "io.sundr.builder";
 
   public static final AttributeKey<TypeDef> ORIGIN_TYPEDEF = new AttributeKey<TypeDef>("ORIGIN_TYPEDEF", TypeDef.class);
-  public static final AttributeKey<TypeDef> OUTER_INTERFACE = new AttributeKey<TypeDef>("OUTER_INTERFACE", TypeDef.class);
-  public static final AttributeKey<TypeDef> OUTER_CLASS = new AttributeKey<TypeDef>("OUTER_CLASS", TypeDef.class);
+  public static final AttributeKey<ClassRef> OUTER_TYPE = new AttributeKey<ClassRef>("OUTER_TYPE", ClassRef.class);
 
   public static final AttributeKey<TypeParamRef> GENERIC_TYPE_REF = new AttributeKey<TypeParamRef>("GENERIC_TYPE_REF",
       TypeParamRef.class);

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/PropertyAs.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/PropertyAs.java
@@ -71,7 +71,7 @@ public final class PropertyAs {
 
       if (unwrapped instanceof ClassRef) {
         TypeDef baseType = GetDefinition.of((ClassRef) unwrapped);
-        ClassRef builderType = TypeAs.SHALLOW_BUILDER.apply(baseType).toReference();
+        ClassRef builderType = TypeAs.BUILDER_REF.apply((ClassRef) unwrapped);
 
         final TypeDef nestedType = NESTED_CLASS_TYPE.apply(item);
         final ClassRef nestedRef = nestedType.toReference();

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToMethod.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToMethod.java
@@ -28,7 +28,6 @@ import static io.sundr.builder.internal.functions.TypeAs.ARRAY_OF;
 import static io.sundr.builder.internal.functions.TypeAs.BOXED_OF;
 import static io.sundr.builder.internal.functions.TypeAs.BUILDER;
 import static io.sundr.builder.internal.functions.TypeAs.FLUENT_REF;
-import static io.sundr.builder.internal.functions.TypeAs.SHALLOW_BUILDER;
 import static io.sundr.builder.internal.functions.TypeAs.UNWRAP_ARRAY_OF;
 import static io.sundr.builder.internal.functions.TypeAs.UNWRAP_COLLECTION_OF;
 import static io.sundr.builder.internal.functions.TypeAs.UNWRAP_OPTIONAL_OF;
@@ -1237,7 +1236,7 @@ class ToMethod {
     }
 
     ClassRef unwrappedClassRef = (ClassRef) unwrappedType;
-    ClassRef builderType = SHALLOW_BUILDER.apply(GetDefinition.of(unwrappedClassRef)).toReference();
+    ClassRef builderType = TypeAs.BUILDER_REF.apply(unwrappedClassRef);
 
     //Let's reload the class from the repository if available....
     TypeDef propertyTypeDef = BuilderContextManager.getContext().getDefinitionRepository()

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToPojo.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToPojo.java
@@ -680,7 +680,7 @@ public class ToPojo implements Function<RichTypeDef, TypeDef> {
           Types.allProperties(generatedPojo).stream().map(i -> i.getTypeRef()).filter(i -> i instanceof ClassRef)
               .forEach(i -> populateReferences((ClassRef) i, generatedRefs));
           adapterImports.addAll(generatedRefs);
-          adapterImports.add(TypeAs.SHALLOW_BUILDER.apply(generatedPojo).toInternalReference());
+          adapterImports.add(TypeAs.BUILDER_REF.apply(generatedPojo.toReference()));
 
           Types.allProperties(generatedPojo).stream()
               .filter(p -> p.getTypeRef() instanceof ClassRef)

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/processor/AbstractBuilderProcessor.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/processor/AbstractBuilderProcessor.java
@@ -39,7 +39,6 @@ import io.sundr.builder.annotations.Inline;
 import io.sundr.builder.internal.BuilderContext;
 import io.sundr.builder.internal.BuilderContextManager;
 import io.sundr.builder.internal.functions.ClazzAs;
-import io.sundr.builder.internal.functions.TypeAs;
 import io.sundr.builder.internal.utils.BuilderUtils;
 import io.sundr.codegen.apt.processor.AbstractCodeGeneratingProcessor;
 import io.sundr.model.ClassRef;
@@ -94,13 +93,13 @@ public abstract class AbstractBuilderProcessor extends AbstractCodeGeneratingPro
     return elements.getTypeElement(c) != null;
   }
 
-  static TypeDef inlineableOf(BuilderContext ctx, TypeDef type, Inline inline) {
+  static TypeDef inlineableOf(BuilderContext ctx, RichTypeDef type, Inline inline) {
     final String inlineableName = !inline.name().isEmpty()
         ? inline.name()
         : inline.prefix() + type.getName() + inline.suffix();
 
     List<Method> constructors = new ArrayList<Method>();
-    final TypeDef builderType = TypeAs.BUILDER.apply(type);
+    final TypeDef builderType = ClazzAs.BUILDER.apply(type);
     TypeDef inlineType = BuilderUtils.getInlineType(ctx, inline);
     TypeDef returnType = BuilderUtils.getInlineReturnType(ctx, inline, type);
     final ClassRef inlineTypeRef = inlineType.toReference(returnType.toReference());
@@ -116,7 +115,7 @@ public abstract class AbstractBuilderProcessor extends AbstractCodeGeneratingPro
     TypeRef functionType = Constants.FUNCTION.toReference(type.toInternalReference(), returnType.toInternalReference());
 
     Property builderProperty = new PropertyBuilder()
-        .withTypeRef(TypeAs.BUILDER.apply(type).toInternalReference())
+        .withTypeRef(builderType.toInternalReference())
         .withName(BUILDER)
         .withNewModifiers().withPrivate().withFinal().endModifiers()
         .build();
@@ -233,11 +232,11 @@ public abstract class AbstractBuilderProcessor extends AbstractCodeGeneratingPro
       ExternalBuildables externalBuildables = typeDef.getAttribute(EXTERNAL_BUILDABLE);
       if (buildable != null) {
         for (final Inline inline : buildable.inline()) {
-          generate(inlineableOf(ctx, typeDef, inline));
+          generate(inlineableOf(ctx, richTypeDef, inline));
         }
       } else if (externalBuildables != null) {
         for (final Inline inline : externalBuildables.inline()) {
-          generate(inlineableOf(ctx, typeDef, inline));
+          generate(inlineableOf(ctx, richTypeDef, inline));
         }
       }
     }

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/utils/BuilderUtils.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/utils/BuilderUtils.java
@@ -70,7 +70,6 @@ import io.sundr.model.AnnotationRef;
 import io.sundr.model.Attributeable;
 import io.sundr.model.ClassRef;
 import io.sundr.model.ClassRefBuilder;
-import io.sundr.model.Kind;
 import io.sundr.model.Method;
 import io.sundr.model.MethodBuilder;
 import io.sundr.model.Nameable;
@@ -602,13 +601,6 @@ public class BuilderUtils {
     return "";
   }
 
-  public static ClassRef buildableRef(TypeRef typeRef) {
-    ClassRef unwrapped = (ClassRef) TypeAs.combine(UNWRAP_COLLECTION_OF, UNWRAP_ARRAY_OF, UNWRAP_OPTIONAL_OF).apply(typeRef);
-    return isAbstract(unwrapped) || GetDefinition.of(unwrapped).getKind() == Kind.INTERFACE
-        ? TypeAs.VISITABLE_BUILDER.apply(unwrapped)
-        : TypeAs.BUILDER.apply(GetDefinition.of(unwrapped)).toInternalReference();
-  }
-
   public static Property arrayAsList(Property property) {
     TypeRef typeRef = property.getTypeRef();
     TypeRef unwrapped = TypeAs.combine(UNWRAP_COLLECTION_OF, UNWRAP_ARRAY_OF, UNWRAP_OPTIONAL_OF).apply(typeRef);
@@ -647,8 +639,8 @@ public class BuilderUtils {
     // For fields that are concrete we can possibly create an instance of a VisitableBuilder.
     // For everything else we can have a builder e.g. Builder<Foo> = () -> fooInstance but it won't be visitable
     ClassRef builderType = Types.isConcrete(targetType)
-        ? TypeAs.BUILDER.apply(GetDefinition.of(targetType)).toInternalReference()
-        : TypeAs.VISITABLE_BUILDER.apply(targetType);
+        ? TypeAs.BUILDER_REF.apply(targetType)
+        : TypeAs.VISITABLE_BUILDER_REF.apply(targetType);
 
     if (isArray || isList) {
       ClassRef listRef = isArray || isAbstractList

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/visitors/InitEnricher.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/visitors/InitEnricher.java
@@ -77,8 +77,8 @@ public class InitEnricher implements Visitor<PropertyBuilder> {
       ClassRef unwarppedClassRef = (unwrapped instanceof ClassRef) ? (ClassRef) unwrapped : null;
 
       targetType = isAbstract(unwarppedClassRef) || GetDefinition.of(unwarppedClassRef).getKind() == Kind.INTERFACE
-          ? TypeAs.VISITABLE_BUILDER.apply(unwarppedClassRef)
-          : TypeAs.BUILDER.apply(GetDefinition.of(unwarppedClassRef)).toInternalReference();
+          ? TypeAs.VISITABLE_BUILDER_Q_REF.apply(unwarppedClassRef)
+          : TypeAs.BUILDER_REF.apply(unwarppedClassRef);
     }
 
     boolean isArray = Types.isArray(typeRef);

--- a/annotations/builder/src/test/java/io/sundr/builder/internal/functions/TypeAsTest.java
+++ b/annotations/builder/src/test/java/io/sundr/builder/internal/functions/TypeAsTest.java
@@ -1,0 +1,50 @@
+package io.sundr.builder.internal.functions;
+
+import static io.sundr.builder.internal.functions.TypeAs.UNWRAP_COLLECTION_OF;
+import static io.sundr.model.utils.Collections.HASH_MAP;
+import static io.sundr.model.utils.Collections.LIST;
+import static io.sundr.model.utils.Collections.MAP;
+import static io.sundr.model.utils.Types.STRING_REF;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.sundr.model.ClassRef;
+import io.sundr.model.TypeParamRefBuilder;
+import io.sundr.model.TypeRef;
+import io.sundr.model.repo.DefinitionRepository;
+import io.sundr.model.utils.Optionals;
+
+public class TypeAsTest {
+
+  @Before
+  public void setUp() throws Exception {
+    DefinitionRepository.getRepository().register(MAP);
+    DefinitionRepository.getRepository().register(LIST);
+    DefinitionRepository.getRepository().register(HASH_MAP);
+  }
+
+  @Test
+  public void shouldUnwrapCollection() {
+    ClassRef ref = LIST.toReference(STRING_REF);
+    TypeRef unwrapped = UNWRAP_COLLECTION_OF.apply(ref);
+    assertEquals(unwrapped, STRING_REF);
+  }
+
+  @Test
+  public void shouldUnwrapCollectionOfOptionals() {
+    ClassRef optionalString = Optionals.OPTIONAL.toReference(STRING_REF);
+    ClassRef ref = LIST.toReference(optionalString);
+    TypeRef unwrapped = UNWRAP_COLLECTION_OF.apply(ref);
+    assertEquals(unwrapped, optionalString);
+  }
+
+  @Test
+  public void shouldUnwrapCollectionOfOptionalParamRef() {
+    ClassRef optionalRef = Optionals.OPTIONAL.toReference(new TypeParamRefBuilder().withName("N").build());
+    ClassRef ref = LIST.toReference(optionalRef);
+    TypeRef unwrapped = UNWRAP_COLLECTION_OF.apply(ref);
+    assertEquals(unwrapped, optionalRef);
+  }
+}

--- a/maven-plugin/src/main/java/io/sundr/maven/GenerateBomMojo.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/GenerateBomMojo.java
@@ -373,7 +373,7 @@ public class GenerateBomMojo extends AbstractSundrioMojo {
     toBuild.getModel().setProfiles(project.getModel().getProfiles());
 
     //We want to avoid having the generated stuff wiped.
-    toBuild.getProperties().put("clean.skip", "true");  // for maven clean 2.x
+    toBuild.getProperties().put("clean.skip", "true"); // for maven clean 2.x
     toBuild.getProperties().put("maven.clean.skip", "true"); // for maven clean 3.x
     toBuild.getModel().getBuild().setDirectory(bomDir.getAbsolutePath());
     toBuild.getModel().getBuild().setOutputDirectory(new File(bomDir, "target").getAbsolutePath());

--- a/model/utils/src/main/java/io/sundr/model/utils/Collections.java
+++ b/model/utils/src/main/java/io/sundr/model/utils/Collections.java
@@ -184,8 +184,8 @@ public class Collections {
    * If the supplied type implements {@link java.util.Collection} (directly or indirectly), determine its generic element type.
    * Otherwise, return {@link Optional#empty()}
    */
-  public static Optional<TypeRef> getCollectionElementType(TypeRef collectionType) {
-    return extractArgument(collectionType, AS_COLLECTION, 0);
+  public static Optional<TypeRef> getCollectionElementType(TypeRef type) {
+    return extractArgument(type, AS_COLLECTION, 0);
   }
 
   /**


### PR DESCRIPTION
TypeDef are used more than they need to in the builder module. So we end up having a lot of `ClassRef` -> `TypeDef` -> `ClassRef`. 

This costs time, memory and code complexity.

This pull request simplifies the code:
- `toEquals` now works for all Nameable types.
- `OUTER_CLASS` and `OUTER_INTERFACE` renamed to `OUTER_TYPE` that accepts a `ClassRef` value.
- Most of TypeAs Typedef function have been converted to their ClassRef equivallents.