### PR TITLE
fix fabric8#4696: removing the possibility of recursion / minor cleanups

### DIFF
--- a/adapters/apt/src/main/java/io/sundr/adapter/apt/AptContext.java
+++ b/adapters/apt/src/main/java/io/sundr/adapter/apt/AptContext.java
@@ -120,4 +120,10 @@ public class AptContext extends AttributeSupport implements AdapterContextAware 
   public Set<TypeElement> getReferences() {
     return this.references;
   }
+
+  public void addReference(TypeElement element) {
+    if (!getDefinitionRepository().hasDefinition(element.toString())) {
+      this.references.add(element);
+    }
+  }
 }

--- a/adapters/apt/src/main/java/io/sundr/adapter/apt/TypeMirrorToTypeRef.java
+++ b/adapters/apt/src/main/java/io/sundr/adapter/apt/TypeMirrorToTypeRef.java
@@ -53,7 +53,7 @@ public class TypeMirrorToTypeRef implements Function<TypeMirror, TypeRef> {
     if (typeRef instanceof ClassRef && element instanceof TypeElement) {
       TypeElement typeElement = (TypeElement) element;
       String fqcn = typeElement.toString();
-      context.getReferences().add((TypeElement) element);
+      context.addReference(typeElement);
       return new ClassRefBuilder((ClassRef) typeRef).withFullyQualifiedName(fqcn).build();
     }
     return typeRef;

--- a/adapters/apt/src/main/java/io/sundr/adapter/apt/visitors/TypeRefTypeVisitor.java
+++ b/adapters/apt/src/main/java/io/sundr/adapter/apt/visitors/TypeRefTypeVisitor.java
@@ -70,9 +70,7 @@ public class TypeRefTypeVisitor extends AbstractTypeVisitor6<TypeRef, Integer> {
     TypeElement element = (TypeElement) t.asElement();
 
     //TODO: need a cleaner way to get this registered.
-    if (!context.getDefinitionRepository().hasDefinition(element.toString())) {
-      context.getReferences().add(element);
-    }
+    context.addReference(element);
 
     String fqcn = element.toString();
     return new ClassRefBuilder().withFullyQualifiedName(fqcn).withDimensions(dimension)


### PR DESCRIPTION
This is to address https://github.com/fabric8io/kubernetes-client/issues/4696 

There seems to be some cyclic scenario by which https://github.com/sundrio/sundrio/compare/main...shawkins:sundrio:main?expand=1#diff-1a754a10b5fe2941b48e2679387036239955a627bdf6d91224e2fa027c22f1a9L205 is problematic as it will call a recursive apply, which simply keeps going - likely due to the adding back in of an already defined reference https://github.com/sundrio/sundrio/compare/main...shawkins:sundrio:main?expand=1#diff-d7549b773b04d789a391084d7bc6749f927ff73fd3243a5a3a7588a85e4305b8L56

These changes minimize recursion and ensure that each level of applied called must be an unknown type.