### PR TITLE
minor changes related to Editable

### DIFF
--- a/annotations/builder/readme.md
+++ b/annotations/builder/readme.md
@@ -330,7 +330,7 @@ Circle circle = new CircleBuilder()
                       .build();
 
 // Create a new CircleBuilder with edit(), set props and the build
-Circle clone = ((Editable) circle).edit().withRadius(120).build();
+Circle clone = ((EditableCircle) circle).edit().withRadius(120).build();
 ```
 
 You can disable this behaviour by using `@Buildable(editableEnabled =

--- a/core/src/main/java/io/sundr/builder/BaseFluent.java
+++ b/core/src/main/java/io/sundr/builder/BaseFluent.java
@@ -40,10 +40,15 @@ public class BaseFluent<F extends Fluent<F>> implements Fluent<F>, Visitable<F> 
     }
 
     try {
-      return (VisitableBuilder<T, ?>) Class.forName(item.getClass().getName() + "Builder").getConstructor(item.getClass())
+      return (VisitableBuilder<T, ?>) Class.forName(item.getClass().getName() + "Builder", true, item.getClass().getClassLoader()).getConstructor(item.getClass())
           .newInstance(item);
     } catch (Exception e) {
-      throw new IllegalStateException("Failed to create builder for: " + item.getClass(), e);
+      try {
+        return (VisitableBuilder<T, ?>) Class.forName(item.getClass().getName() + "Builder").getConstructor(item.getClass())
+            .newInstance(item);
+      } catch (Exception e1) {
+        throw new IllegalStateException("Failed to create builder for: " + item.getClass(), e1);
+      }
     }
   }
 
@@ -63,6 +68,7 @@ public class BaseFluent<F extends Fluent<F>> implements Fluent<F>, Visitable<F> 
     return new LinkedHashSet(Arrays.stream(sets).filter(Objects::nonNull).collect(Collectors.toSet()));
   }
 
+  @Override
   public F accept(Visitor... visitors) {
     return accept(Collections.emptyList(), visitors);
   }
@@ -87,6 +93,7 @@ public class BaseFluent<F extends Fluent<F>> implements Fluent<F>, Visitable<F> 
     });
   }
 
+  @Override
   public F accept(List<Entry<String, Object>> path, String currentKey, Visitor... visitors) {
     List<Visitor> sortedVisitor = new ArrayList<>();
     for (Visitor visitor : visitors) {


### PR DESCRIPTION
correcting the readme and looking at both the context and the class's classloader for the builder.

@iocanel @manusa on the Editable interface, currently there's need for it to be generic, it could just as easily be defined as:

```
public interface Editable {

  VisitableBuilder<?, ?> edit();
}
```
or to match the behavior in BaseFluent.builderOf
```
public interface Editable<T> {

  VisitableBuilder<T, ?> edit();
}
```
However either of these would likely be considered breaking changes, so I'm not sure if it's worth pursuing.
