### PR TITLE
Post fluent / fluentImpl changes

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
@@ -205,19 +205,6 @@ public class ClazzAs {
         } else if (!descendants.isEmpty()) {
           properties.add(buildableField(toAdd));
           for (Property descendant : descendants) {
-            if (Types.isCollection(descendant.getTypeRef())) {
-              methods.addAll(ToMethod.ADD_TO_COLLECTION.apply(descendant).stream()
-                  .map(m -> new MethodBuilder(m).addToAnnotations(DEPRECATED_ANNOTATION)
-                      .addToComments("@deprecated Use a addTo/setTo method referencing a parent type instead").build())
-                  .collect(Collectors.toList()));
-              methods.addAll(ToMethod.REMOVE_FROM_COLLECTION.apply(descendant).stream()
-                  .map(m -> new MethodBuilder(m).addToAnnotations(DEPRECATED_ANNOTATION)
-                      .addToComments("@deprecated Use a remove method referencing a parent type instead").build())
-                  .collect(Collectors.toList()));
-            } else {
-              methods.add(new MethodBuilder(ToMethod.WITH.apply(descendant)).addToAnnotations(DEPRECATED_ANNOTATION)
-                  .addToComments("@deprecated Use a with method referencing a parent type instead").build());
-            }
             methods.add(ToMethod.WITH_NEW_NESTED.apply(descendant));
             methods.add(ToMethod.WITH_NEW_LIKE_NESTED.apply(descendant));
             methods.addAll(ToMethod.WITH_NESTED_INLINE.apply(descendant));
@@ -289,7 +276,7 @@ public class ClazzAs {
       BlockNested<MethodBuilder> builderBuilder = new MethodBuilder().withNewModifiers().withProtected().withStatic()
           .endModifiers()
           .withParameters(Types.T)
-          .withArguments(new PropertyBuilder().withName("item").withTypeRef(Types.OBJECT_REF).build())
+          .addNewArgument().withName("item").withTypeRef(Types.OBJECT_REF).endArgument()
           .withReturnType(BuilderContextManager.getContext().getVisitableBuilderInterface().toReference(Types.T_REF))
           .withName("builder").withNewBlock();
       builderBuilder.addToStatements(new StringStatement("switch (item.getClass().getName()) {"));

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToMethod.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToMethod.java
@@ -1174,6 +1174,13 @@ class ToMethod {
       String delegatePrefix = IS_COLLECTION.apply(property.getTypeRef()) ? "addTo" : "with";
       String delegateName = delegatePrefix + property.getNameCapitalized();
 
+      if (property.hasAttribute(Constants.DESCENDANT_OF)) {
+        Property attrValue = property.getAttribute(Constants.DESCENDANT_OF);
+        if (attrValue != null) {
+          delegateName = delegatePrefix + (attrValue).getNameCapitalized();
+        }
+      }
+
       String args = Strings.join(constructor.getArguments(), Property::getName, ", ");
 
       result.add(new MethodBuilder()


### PR DESCRIPTION
This won't be ready for main until after #263 has been merged - the second commit are the new changes.

@iocanel I see that the changes to have fallbacks everywhere are incomplete - several locations do not do proper null handling of the collection field.  However I would like to propose rather than simply adding/refactoring those in, to simplify the methods to consolidate where the builder is coming from.

To assist with that these changes include a lookup table for all of the known types to avoid reflection for known types, but from what I can see locally you typically save less than 1 microsecond per invocation when the type is found in the instanceof chain or this lookup table vs calling builderOf.  So it would be fine to not even use this additional lookup method as well.

With that there are also several deprecations to the subtype methods.  For all of these methods there is a more general method that will work.  In particular removeMatchingFromXXXCollection methods should just use the removeMatchingFromCollection method - there's no conversion to a bulider involved there at all.  With the other consolidation of the builder logic, I would go further and deprecate methods like removeAllFromXXXCollection, withXXXField as there is also a removeAllFromCollection, withField, etc.