### PR TITLE
fix #383: marking builder methods as deprecated if the property is

### DIFF
--- a/tests/shapes/src/main/java/io/sundr/examples/shapes/Canvas.java
+++ b/tests/shapes/src/main/java/io/sundr/examples/shapes/Canvas.java
@@ -31,6 +31,7 @@ import io.sundr.transform.annotations.TemplateTransformation;
 @TemplateTransformation("transformation.vm") //This is just used to demonstrate how we can use velocity transformations.
 public class Canvas {
 
+  @Deprecated
   private final Shape canvasShape;
   private final Map<String, Shape> namedShapes;
   private final List<Shape> shapes;

--- a/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
+++ b/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
@@ -16,6 +16,9 @@
 
 package io.sundr.examples.shapes;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
@@ -32,8 +35,6 @@ import io.sundr.examples.shapes.v1.CircleBuilder;
 import io.sundr.examples.shapes.v1.EditableCircle;
 import io.sundr.examples.shapes.v1.Square;
 import io.sundr.examples.shapes.v1.SquareBuilder;
-
-import static org.junit.Assert.assertEquals;
 
 public class ShapesTest {
 
@@ -366,5 +367,10 @@ public class ShapesTest {
     EditableCanvas canvas = new CanvasBuilder()
         .addToShapes(-1, new SquareBuilder()).build();
     assertEquals(1, canvas.getShapes().size());
+  }
+  
+  @Test
+  public void testDeprecatedField() throws Exception {
+    assertNotNull(CanvasBuilder.class.getMethod("hasCanvasShape").getAnnotation(Deprecated.class));
   }
 }


### PR DESCRIPTION
This is only checking the field, a case could be made to look at the getter/setter as well.