### PR TITLE
Add isEnumConstant and isSynthetic to the Property model

### DIFF
--- a/adapters/api/src/test/java/io/sundr/adapter/testing/AbstractAdapterTest.java
+++ b/adapters/api/src/test/java/io/sundr/adapter/testing/AbstractAdapterTest.java
@@ -186,7 +186,9 @@ public abstract class AbstractAdapterTest<T> {
     assertTrue(personType.isPresent());
     personType.ifPresent(p -> {
       assertEquals(Person.class.getName() + ".Type", p.getFullyQualifiedName());
-      Set<String> properties = GetDefinition.of(p).getProperties().stream().map(Property::getName).collect(Collectors.toSet());
+      Set<String> properties = GetDefinition.of(p).getProperties().stream()
+          .filter(prop -> prop.isEnumConstant() && !prop.isSynthetic()).map(Property::getName).collect(Collectors.toSet());
+      assertEquals(8, properties.size());
       assertTrue(properties.contains("O_MINUS"));
     });
 
@@ -201,8 +203,10 @@ public abstract class AbstractAdapterTest<T> {
       assertTrue(addressType.isPresent());
       addressType.ifPresent(a -> {
         assertEquals(Address.class.getName() + ".Type", a.getFullyQualifiedName());
-        Set<String> properties = GetDefinition.of(a).getProperties().stream().map(Property::getName)
+        Set<String> properties = GetDefinition.of(a).getProperties().stream()
+            .filter(prop -> prop.isEnumConstant() && prop.isSynthetic()).map(Property::getName)
             .collect(Collectors.toSet());
+        assertEquals(2, properties.size());
         assertTrue(properties.contains("WORK"));
       });
     });

--- a/adapters/api/src/test/java/io/sundr/adapter/testing/AbstractAdapterTest.java
+++ b/adapters/api/src/test/java/io/sundr/adapter/testing/AbstractAdapterTest.java
@@ -204,7 +204,7 @@ public abstract class AbstractAdapterTest<T> {
       addressType.ifPresent(a -> {
         assertEquals(Address.class.getName() + ".Type", a.getFullyQualifiedName());
         Set<String> properties = GetDefinition.of(a).getProperties().stream()
-            .filter(prop -> prop.isEnumConstant() && prop.isSynthetic()).map(Property::getName)
+            .filter(prop -> prop.isEnumConstant() && !prop.isSynthetic()).map(Property::getName)
             .collect(Collectors.toSet());
         assertEquals(2, properties.size());
         assertTrue(properties.contains("WORK"));

--- a/adapters/api/src/test/java/io/sundr/adapter/testing/person/Address.java
+++ b/adapters/api/src/test/java/io/sundr/adapter/testing/person/Address.java
@@ -25,6 +25,10 @@ public class Address {
   private Type type;
 
   enum Type {
-    HOME, WORK
+    HOME, WORK;
+
+    static final Type getDefault() {
+      return HOME;
+    }
   }
 }

--- a/adapters/api/src/test/java/io/sundr/adapter/testing/person/Person.java
+++ b/adapters/api/src/test/java/io/sundr/adapter/testing/person/Person.java
@@ -29,6 +29,10 @@ public class Person {
   private List<Address> addresses;
 
   public enum Type {
-    A_MINUS, A_PLUS, B_MINUS, B_PLUS, AB_MINUS, AB_PLUS, O_MINUS, O_PLUS
+    A_MINUS, A_PLUS, B_MINUS, B_PLUS, AB_MINUS, AB_PLUS, O_MINUS, O_PLUS;
+
+    static final Type getDefault() {
+      return A_PLUS;
+    }
   }
 }

--- a/adapters/apt/src/main/java/io/sundr/adapter/apt/VariableElementToProperty.java
+++ b/adapters/apt/src/main/java/io/sundr/adapter/apt/VariableElementToProperty.java
@@ -32,6 +32,7 @@ import io.sundr.model.Modifiers;
 import io.sundr.model.Property;
 import io.sundr.model.PropertyBuilder;
 import io.sundr.model.TypeRef;
+import io.sundr.model.utils.Types;
 import io.sundr.utils.Strings;
 
 public class VariableElementToProperty implements Function<VariableElement, Property> {
@@ -53,6 +54,7 @@ public class VariableElementToProperty implements Function<VariableElement, Prop
     String name = variableElement.getSimpleName().toString();
 
     TypeRef type = referenceAdapterFunction.apply(variableElement.asType());
+    boolean isEnum = Types.isEnum(type);
     List<AnnotationRef> annotations = new ArrayList<AnnotationRef>();
     for (AnnotationMirror annotationMirror : variableElement.getAnnotationMirrors()) {
       annotations.add(annotationAdapterFunction.apply(annotationMirror));
@@ -62,7 +64,10 @@ public class VariableElementToProperty implements Function<VariableElement, Prop
     List<String> commentList = Strings.isNullOrEmpty(comments) ? new ArrayList<>()
         : Arrays.stream(comments.split(NEWLINE_PATTERN)).map(String::trim).filter(s -> !s.isEmpty())
             .collect(Collectors.toList());
+
     return new PropertyBuilder().withComments(commentList).withName(name).withTypeRef(type).withAnnotations(annotations)
+        .withEnumConstant(isEnum)
+        .withSynthetic(false)
         .withModifiers(Modifiers.from(variableElement.getModifiers())).build();
   }
 

--- a/adapters/reflect/src/main/java/io/sundr/adapter/reflect/ClassToTypeDef.java
+++ b/adapters/reflect/src/main/java/io/sundr/adapter/reflect/ClassToTypeDef.java
@@ -182,6 +182,8 @@ public class ClassToTypeDef implements Function<Class, TypeDef> {
       properties.add(new PropertyBuilder()
           .withName(field.getName())
           .withModifiers(Modifiers.from(field.getModifiers()))
+          .withEnumConstant(field.isEnumConstant())
+          .withSynthetic(field.isSynthetic())
           .withAnnotations(annotationRefs)
           .withTypeRef(typeToTypeRef.apply(field.getGenericType()))
           .build());

--- a/adapters/reflect/src/main/java/io/sundr/reflect/ClassTo.java
+++ b/adapters/reflect/src/main/java/io/sundr/reflect/ClassTo.java
@@ -278,9 +278,12 @@ public class ClassTo {
             .filter(c -> !item.equals(c))
             .collect(Collectors.toList()));
       }
+
       properties.add(new PropertyBuilder()
           .withName(field.getName())
           .withModifiers(Modifiers.from(field.getModifiers()))
+          .isEnumConstant(field.isEnumConstant())
+          .isSynthetic(field.isSynthetic())
           .withAnnotations(annotationRefs)
           .withTypeRef(TYPEREF.apply(field.getGenericType()))
           .build());

--- a/adapters/reflect/src/main/java/io/sundr/reflect/ClassTo.java
+++ b/adapters/reflect/src/main/java/io/sundr/reflect/ClassTo.java
@@ -282,8 +282,8 @@ public class ClassTo {
       properties.add(new PropertyBuilder()
           .withName(field.getName())
           .withModifiers(Modifiers.from(field.getModifiers()))
-          .isEnumConstant(field.isEnumConstant())
-          .isSynthetic(field.isSynthetic())
+          .withEnumConstant(field.isEnumConstant())
+          .withSynthetic(field.isSynthetic())
           .withAnnotations(annotationRefs)
           .withTypeRef(TYPEREF.apply(field.getGenericType()))
           .build());

--- a/model/base/src/main/java/io/sundr/model/Property.java
+++ b/model/base/src/main/java/io/sundr/model/Property.java
@@ -46,6 +46,18 @@ public class Property extends ModifierSupport implements Renderable, Commentable
     this.synthetic = synthetic;
   }
 
+  @Deprecated
+  public Property(List<AnnotationRef> annotations, TypeRef typeRef, String name, List<String> comments, Modifiers modifiers,
+      Map<AttributeKey, Object> attributes) {
+    super(modifiers, attributes);
+    this.annotations = annotations;
+    this.typeRef = typeRef;
+    this.name = name;
+    this.comments = comments;
+    this.enumConstant = false;
+    this.synthetic = false;
+  }
+
   public static Property newProperty(TypeRef typeRef, String name) {
     return new Property(Collections.emptyList(), typeRef, name, Collections.emptyList(), false, false, Modifiers.create(),
         new HashMap<>());

--- a/model/base/src/main/java/io/sundr/model/Property.java
+++ b/model/base/src/main/java/io/sundr/model/Property.java
@@ -32,18 +32,23 @@ public class Property extends ModifierSupport implements Renderable, Commentable
   private final TypeRef typeRef;
   private final String name;
   private final List<String> comments;
+  private final boolean enumConstant;
+  private final boolean synthetic;
 
-  public Property(List<AnnotationRef> annotations, TypeRef typeRef, String name, List<String> comments, Modifiers modifiers,
-      Map<AttributeKey, Object> attributes) {
+  public Property(List<AnnotationRef> annotations, TypeRef typeRef, String name, List<String> comments, boolean enumConstant,
+      boolean synthetic, Modifiers modifiers, Map<AttributeKey, Object> attributes) {
     super(modifiers, attributes);
     this.annotations = annotations;
     this.typeRef = typeRef;
     this.name = name;
     this.comments = comments;
+    this.enumConstant = enumConstant;
+    this.synthetic = synthetic;
   }
 
   public static Property newProperty(TypeRef typeRef, String name) {
-    return new Property(Collections.emptyList(), typeRef, name, Collections.emptyList(), Modifiers.create(), new HashMap<>());
+    return new Property(Collections.emptyList(), typeRef, name, Collections.emptyList(), false, false, Modifiers.create(),
+        new HashMap<>());
   }
 
   public List<AnnotationRef> getAnnotations() {
@@ -60,6 +65,14 @@ public class Property extends ModifierSupport implements Renderable, Commentable
 
   public List<String> getComments() {
     return this.comments;
+  }
+
+  public boolean isEnumConstant() {
+    return this.enumConstant;
+  }
+
+  public boolean isSynthetic() {
+    return this.synthetic;
   }
 
   public String getNameCapitalized() {
@@ -101,7 +114,7 @@ public class Property extends ModifierSupport implements Renderable, Commentable
    * @return the property without any modifiers
    */
   protected Property withoutModiers() {
-    return new Property(annotations, typeRef, name, comments, Modifiers.create(), getAttributes());
+    return new Property(annotations, typeRef, name, comments, enumConstant, synthetic, Modifiers.create(), getAttributes());
   }
 
   /**
@@ -112,7 +125,7 @@ public class Property extends ModifierSupport implements Renderable, Commentable
    */
   public Property withErasure() {
     return new Property(annotations, typeRef instanceof TypeParamRef ? ((TypeParamRef) typeRef).withErasure() : typeRef, name,
-        comments, Modifiers.create(), getAttributes());
+        comments, enumConstant, synthetic, Modifiers.create(), getAttributes());
   }
 
   protected String getDefaultValue() {
@@ -145,6 +158,10 @@ public class Property extends ModifierSupport implements Renderable, Commentable
       if (other.typeRef != null)
         return false;
     } else if (!typeRef.equals(other.typeRef))
+      return false;
+    if (enumConstant != other.isEnumConstant())
+      return false;
+    if (synthetic != other.isSynthetic())
       return false;
     return true;
   }

--- a/model/builder/src/main/java/io/sundr/model/ClassRefFluentImpl.java
+++ b/model/builder/src/main/java/io/sundr/model/ClassRefFluentImpl.java
@@ -816,9 +816,6 @@ public class ClassRefFluentImpl<A extends ClassRefFluent<A>> extends TypeRefFlue
   }
 
   public String toString() {
-    if (true) {
-      return fullyQualifiedName;
-    }
     StringBuilder sb = new StringBuilder();
     sb.append("{");
     if (fullyQualifiedName != null) {

--- a/model/builder/src/main/java/io/sundr/model/PropertyBuilder.java
+++ b/model/builder/src/main/java/io/sundr/model/PropertyBuilder.java
@@ -34,6 +34,8 @@ public class PropertyBuilder extends PropertyFluentImpl<PropertyBuilder>
     fluent.withTypeRef(instance.getTypeRef());
     fluent.withName(instance.getName());
     fluent.withComments(instance.getComments());
+    fluent.withEnumConstant(instance.isEnumConstant());
+    fluent.withSynthetic(instance.isSynthetic());
     fluent.withModifiers(instance.getModifiers());
     fluent.withAttributes(instance.getAttributes());
     this.validationEnabled = validationEnabled;
@@ -49,6 +51,8 @@ public class PropertyBuilder extends PropertyFluentImpl<PropertyBuilder>
     this.withTypeRef(instance.getTypeRef());
     this.withName(instance.getName());
     this.withComments(instance.getComments());
+    this.withEnumConstant(instance.isEnumConstant());
+    this.withSynthetic(instance.isSynthetic());
     this.withModifiers(instance.getModifiers());
     this.withAttributes(instance.getAttributes());
     this.validationEnabled = validationEnabled;
@@ -59,7 +63,7 @@ public class PropertyBuilder extends PropertyFluentImpl<PropertyBuilder>
 
   public Property build() {
     Property buildable = new Property(fluent.getAnnotations(), fluent.getTypeRef(), fluent.getName(), fluent.getComments(),
-        fluent.getModifiers(), fluent.getAttributes());
+        fluent.isEnumConstant(), fluent.isSynthetic(), fluent.getModifiers(), fluent.getAttributes());
     return buildable;
   }
 

--- a/model/builder/src/main/java/io/sundr/model/PropertyFluent.java
+++ b/model/builder/src/main/java/io/sundr/model/PropertyFluent.java
@@ -148,6 +148,22 @@ public interface PropertyFluent<A extends PropertyFluent<A>> extends ModifierSup
 
   public Boolean hasComments();
 
+  public boolean isEnumConstant();
+
+  public A withEnumConstant(boolean enumConstant);
+
+  public Boolean hasEnumConstant();
+
+  public boolean isSynthetic();
+
+  public A withSynthetic(boolean synthetic);
+
+  public Boolean hasSynthetic();
+
+  public A withEnumConstant();
+
+  public A withSynthetic();
+
   public interface AnnotationsNested<N> extends Nested<N>, AnnotationRefFluent<PropertyFluent.AnnotationsNested<N>> {
     public N and();
 

--- a/model/builder/src/main/java/io/sundr/model/PropertyFluentImpl.java
+++ b/model/builder/src/main/java/io/sundr/model/PropertyFluentImpl.java
@@ -28,6 +28,8 @@ public class PropertyFluentImpl<A extends PropertyFluent<A>> extends ModifierSup
     this.withTypeRef(instance.getTypeRef());
     this.withName(instance.getName());
     this.withComments(instance.getComments());
+    this.withEnumConstant(instance.isEnumConstant());
+    this.withSynthetic(instance.isSynthetic());
     this.withModifiers(instance.getModifiers());
     this.withAttributes(instance.getAttributes());
   }
@@ -36,6 +38,8 @@ public class PropertyFluentImpl<A extends PropertyFluent<A>> extends ModifierSup
   private VisitableBuilder<? extends TypeRef, ?> typeRef;
   private String name;
   private List<String> comments = new ArrayList<String>();
+  private boolean enumConstant;
+  private boolean synthetic;
 
   public A addToAnnotations(Integer index, AnnotationRef item) {
     if (this.annotations == null) {
@@ -516,6 +520,32 @@ public class PropertyFluentImpl<A extends PropertyFluent<A>> extends ModifierSup
     return comments != null && !comments.isEmpty();
   }
 
+  public boolean isEnumConstant() {
+    return this.enumConstant;
+  }
+
+  public A withEnumConstant(boolean enumConstant) {
+    this.enumConstant = enumConstant;
+    return (A) this;
+  }
+
+  public Boolean hasEnumConstant() {
+    return true;
+  }
+
+  public boolean isSynthetic() {
+    return this.synthetic;
+  }
+
+  public A withSynthetic(boolean synthetic) {
+    this.synthetic = synthetic;
+    return (A) this;
+  }
+
+  public Boolean hasSynthetic() {
+    return true;
+  }
+
   public boolean equals(Object o) {
     if (this == o)
       return true;
@@ -532,11 +562,15 @@ public class PropertyFluentImpl<A extends PropertyFluent<A>> extends ModifierSup
       return false;
     if (comments != null ? !comments.equals(that.comments) : that.comments != null)
       return false;
+    if (enumConstant != that.enumConstant)
+      return false;
+    if (synthetic != that.synthetic)
+      return false;
     return true;
   }
 
   public int hashCode() {
-    return java.util.Objects.hash(annotations, typeRef, name, comments, super.hashCode());
+    return java.util.Objects.hash(annotations, typeRef, name, comments, enumConstant, synthetic, super.hashCode());
   }
 
   public String toString() {
@@ -556,10 +590,22 @@ public class PropertyFluentImpl<A extends PropertyFluent<A>> extends ModifierSup
     }
     if (comments != null && !comments.isEmpty()) {
       sb.append("comments:");
-      sb.append(comments);
+      sb.append(comments + ",");
     }
+    sb.append("enumConstant:");
+    sb.append(enumConstant + ",");
+    sb.append("synthetic:");
+    sb.append(synthetic);
     sb.append("}");
     return sb.toString();
+  }
+
+  public A withEnumConstant() {
+    return withEnumConstant(true);
+  }
+
+  public A withSynthetic() {
+    return withSynthetic(true);
   }
 
   class AnnotationsNestedImpl<N> extends AnnotationRefFluentImpl<PropertyFluent.AnnotationsNested<N>>

--- a/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
+++ b/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
@@ -368,7 +368,7 @@ public class ShapesTest {
         .addToShapes(-1, new SquareBuilder()).build();
     assertEquals(1, canvas.getShapes().size());
   }
-  
+
   @Test
   public void testDeprecatedField() throws Exception {
     assertNotNull(CanvasBuilder.class.getMethod("hasCanvasShape").getAnnotation(Deprecated.class));


### PR DESCRIPTION
@iocanel I need a little assistance here, as re-generating the model Builders and Fluent with `(cd model && make)` doesn't produce the expected result.

The intention here is to surface the information easily accessible using the reflection API, this change should enable a proper fix for:
https://github.com/fabric8io/kubernetes-client/issues/5228
https://github.com/fabric8io/kubernetes-client/issues/4225
