### PR TITLE
fix #394 instance needs to be fully qualified and not abstract

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
@@ -619,8 +619,9 @@ public class ClazzAs {
       statements.add(new StringStatement("this.fluent = " + fluent + "; "));
     }
 
-    if (hasDefaultConstructor(clazz)) {
-      statements.add(new StringStatement("instance = (instance != null ? instance : new " + clazz.getName() + "());\n"));
+    if (!isAbstract(clazz.toReference()) && hasDefaultConstructor(clazz)) {
+      statements.add(
+          new StringStatement("instance = (instance != null ? instance : new " + clazz.getFullyQualifiedName() + "());\n"));
     }
 
     StringBuilder builder = new StringBuilder("if (instance != null) {\n");

--- a/tests/buildable-fields/src/main/java/io/sundr/tests/AbstractWithDefaults.java
+++ b/tests/buildable-fields/src/main/java/io/sundr/tests/AbstractWithDefaults.java
@@ -23,6 +23,16 @@ import io.sundr.builder.annotations.Buildable;
  * A simple Pojo that demonstrates default fields are preserved
  */
 @Buildable
-public class WithDefaults extends AbstractWithDefaults {
+public abstract class AbstractWithDefaults {
+
+  private String field = "Hello";
+
+  public String getField() {
+    return field;
+  }
+
+  public void setField(String field) {
+    this.field = field;
+  }
 
 }


### PR DESCRIPTION
@iocanel sorry about this, ran through the snapshot again with fabric8 and saw a situation where the instance type is fully qualified and the type with the same name is not, which led to a compilation error.  So this needs to be fully qualified.  A simple reproducer didn't seem to induce the behavior though.