### PR TITLE
Removes validationEnabled constructors when not in use

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/BuilderContextManager.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/BuilderContextManager.java
@@ -53,6 +53,9 @@ public class BuilderContextManager {
             + context.getBuilderPackage() + " already exists.");
       } else if (!generateBuilderPackage.equals(context.getGenerateBuilderPackage())) {
         throw new IllegalStateException("Cannot use different values for generate builder package in a single project.");
+      } else if (validationEnabled && !context.isValidationEnabled()) {
+        context = new BuilderContext(elements, types, generateBuilderPackage, validationEnabled, packageName, inlineables);
+        return context;
       } else {
         return context;
       }


### PR DESCRIPTION
also consolidates instance copying

Closes #415

@iocanel in looking at testing can you clarify what the expectations are for the feature - in classAs we check both at a type level and at a BuildContext level for validationEnabled.  However the BuildContextManager will not adjust the value of validationEnabled on the context.  Are users supposed to mark all types as validationEnabled=true?