### PR TITLE
fix: limiting when prefixing is used

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/PropertyAs.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/PropertyAs.java
@@ -213,10 +213,15 @@ public final class PropertyAs {
       }
       parameters.add(N);
 
+      // synthetic properties of descendants need a prefix as the class names may collide
+      String prefix = property.hasAttribute(Constants.DESCENDANT_OF)
+          ? BuilderUtils.fullyQualifiedNameDiff(property.getTypeRef(), originTypeDef)
+          : "";
+
       return new TypeDefBuilder()
           .withKind(Kind.INTERFACE)
           .withPackageName(outerClass.getPackageName())
-          .withName(BuilderUtils.fullyQualifiedNameDiff(property.getTypeRef(), originTypeDef) + property.getNameCapitalized()
+          .withName(prefix + property.getNameCapitalized()
               + "Nested")
           // all references are local - qualified causes compilation errors
           //.withOuterTypeName(outerClass.getFullyQualifiedName())

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToMethod.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToMethod.java
@@ -1183,7 +1183,10 @@ class ToMethod {
     boolean isCollection = IS_COLLECTION.apply(property.getTypeRef());
     String prefix = isCollection ? "addNew" : "withNew";
 
-    prefix += BuilderUtils.fullyQualifiedNameDiff(baseType, originTypeDef);
+    // synthetic properties of descendants need a prefix as the class names may collide
+    if (property.hasAttribute(Constants.DESCENDANT_OF)) {
+      prefix += BuilderUtils.fullyQualifiedNameDiff(baseType, originTypeDef);
+    }
     String methodName = (prefix + (isCollection
         ? Singularize.FUNCTION.apply(property.getNameCapitalized())
         : property.getNameCapitalized()));
@@ -1224,11 +1227,13 @@ class ToMethod {
       boolean isCollection = IS_COLLECTION.apply(property.getTypeRef());
       String ownPrefix = isCollection ? "addNew" : "withNew";
 
-      ownPrefix += BuilderUtils.fullyQualifiedNameDiff(baseType.toInternalReference(), originTypeDef);
+      if (property.hasAttribute(Constants.DESCENDANT_OF)) {
+        ownPrefix += BuilderUtils.fullyQualifiedNameDiff(baseType.toInternalReference(), originTypeDef);
+      }
       String ownName = ownPrefix
           + (isCollection ? Singularize.FUNCTION.apply(property.getNameCapitalized()) : property.getNameCapitalized());
 
-      String delegatePrefix = IS_COLLECTION.apply(property.getTypeRef()) ? "addTo" : "with";
+      String delegatePrefix = isCollection ? "addTo" : "with";
       String delegateName = delegatePrefix + property.getNameCapitalized();
 
       if (property.hasAttribute(Constants.DESCENDANT_OF)) {

--- a/tests/shapes/src/main/java/io/sundr/examples/shapes/Canvas.java
+++ b/tests/shapes/src/main/java/io/sundr/examples/shapes/Canvas.java
@@ -38,6 +38,8 @@ public class Canvas {
   private final Artist artist;
   private final Date date;
   private final Map<String, String> notes;
+  private io.sundr.examples.shapes.v1.Square v1;
+  private io.sundr.examples.shapes.v2.Square v2;
 
   public Canvas(Shape canvasShape, Map<String, Shape> namedShapes, List<Shape> shapes, Artist artist, Date date,
       Map<String, String> notes) {
@@ -72,4 +74,21 @@ public class Canvas {
   public Map<String, String> getNotes() {
     return notes;
   }
+
+  public io.sundr.examples.shapes.v1.Square getV1() {
+    return v1;
+  }
+
+  public io.sundr.examples.shapes.v2.Square getV2() {
+    return v2;
+  }
+
+  public void setV1(io.sundr.examples.shapes.v1.Square v1) {
+    this.v1 = v1;
+  }
+
+  public void setV2(io.sundr.examples.shapes.v2.Square v2) {
+    this.v2 = v2;
+  }
+
 }

--- a/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
+++ b/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
@@ -381,4 +381,11 @@ public class ShapesTest {
     builder.withNewLabel().endLabel().withNewLabel().endLabel();
     assertEquals(1, builder.getVisitableMap().get().get("label").size());
   }
+
+  @Test
+  public void testBuildablePropertyMethodNames() throws Exception {
+    assertNotNull(CanvasBuilder.class.getMethod("withNewV1", null));
+    assertNotNull(CanvasBuilder.class.getMethod("withNewV2", null));
+  }
+
 }


### PR DESCRIPTION
Simple buildable properties with the change are not prefixed as they don't need additional package qualification.

closes #437