### PR TITLE
fix: allows for class names to not start with upper case letters

### DIFF
--- a/model/base/src/main/java/io/sundr/model/Nameable.java
+++ b/model/base/src/main/java/io/sundr/model/Nameable.java
@@ -66,13 +66,27 @@ public interface Nameable extends Node {
   }
 
   static String getClassName(String fullyQualifiedName) {
-    return Arrays.stream(fullyQualifiedName.split(PACKAGE_SEPARATOR_REGEX)).filter(after(IS_UPPER_CASE))
-        .collect(Collectors.joining(DOT));
+    String[] parts = fullyQualifiedName.split(PACKAGE_SEPARATOR_REGEX);
+
+    String result = Arrays.stream(parts).filter(after(IS_UPPER_CASE)).collect(Collectors.joining(DOT));
+
+    if (!result.isEmpty()) {
+      return result;
+    }
+
+    return parts[parts.length - 1];
   }
 
   static String getPackageName(String fullyQualifiedName) {
-    return Arrays.stream(fullyQualifiedName.split(PACKAGE_SEPARATOR_REGEX)).filter(until(IS_UPPER_CASE))
-        .collect(Collectors.joining(DOT));
+    String[] parts = fullyQualifiedName.split(PACKAGE_SEPARATOR_REGEX);
+
+    String result = Arrays.stream(parts).filter(until(IS_UPPER_CASE)).collect(Collectors.joining(DOT));
+
+    if (!result.equals(fullyQualifiedName)) {
+      return result;
+    }
+
+    return Arrays.asList(parts).subList(0, parts.length - 1).stream().collect(Collectors.joining(DOT));
   }
 
   static <T> Predicate<T> until(final Predicate<T> predicate) {

--- a/tests/shapes/src/main/java/io/sundr/examples/shapes/_1Odd.java
+++ b/tests/shapes/src/main/java/io/sundr/examples/shapes/_1Odd.java
@@ -18,39 +18,17 @@ package io.sundr.examples.shapes;
 
 import io.sundr.builder.annotations.Buildable;
 
-public class Artist {
+@Buildable
+public class _1Odd {
 
-  private String firstName;
-  private String lastName;
-  private _1Odd oddity;
+  private String field;
 
-  @Buildable
-  public Artist(String firstName, String lastName) {
-    this.firstName = firstName;
-    this.lastName = lastName;
+  public String getField() {
+    return field;
   }
 
-  public String getFirstName() {
-    return firstName;
+  public void setField(String field) {
+    this.field = field;
   }
 
-  public void setFirstName(String firstName) {
-    this.firstName = firstName;
-  }
-
-  public String getLastName() {
-    return lastName;
-  }
-
-  public void setLastName(String lastName) {
-    this.lastName = lastName;
-  }
-
-  public _1Odd getOddity() {
-    return oddity;
-  }
-
-  public void setOddity(_1Odd oddity) {
-    this.oddity = oddity;
-  }
 }

--- a/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
+++ b/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
@@ -56,6 +56,12 @@ public class ShapesTest {
       return Optional.empty();
     }
   };
+  
+  @Test
+  public void testArtistBuilder() {
+    Artist artist = new ArtistBuilder().withNewOddity().withField("x").endOddity().build();
+    assertEquals("x", artist.getOddity().getField());
+  }
 
   @Test
   public void testCircleBuilder() {


### PR DESCRIPTION
@iocanel the only issue I can see here is that you can't have inner types if you have a class that starts with something other than an upper case.

@andreaTP you could consider changing the generator convention to prepending A instead of _ and everything would work as expected with sundrio.

closes #430