### PR TITLE
fix: ensuring consistency in prefixing

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/PropertyAs.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/PropertyAs.java
@@ -213,15 +213,10 @@ public final class PropertyAs {
       }
       parameters.add(N);
 
-      // synthetic properties of descendants need a prefix as the class names may collide
-      String prefix = property.hasAttribute(Constants.DESCENDANT_OF)
-          ? BuilderUtils.fullyQualifiedNameDiff(property.getTypeRef(), originTypeDef)
-          : "";
-
       return new TypeDefBuilder()
           .withKind(Kind.INTERFACE)
           .withPackageName(outerClass.getPackageName())
-          .withName(prefix + property.getNameCapitalized()
+          .withName(BuilderUtils.qualifyPropertyName(property, property.getTypeRef(), originTypeDef)
               + "Nested")
           // all references are local - qualified causes compilation errors
           //.withOuterTypeName(outerClass.getFullyQualifiedName())

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/utils/BuilderUtils.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/utils/BuilderUtils.java
@@ -29,7 +29,6 @@ import static io.sundr.model.Attributeable.INIT;
 import static io.sundr.model.Attributeable.INIT_FUNCTION;
 import static io.sundr.model.Attributeable.LAZY_INIT;
 import static io.sundr.model.utils.Types.STRING_REF;
-import static io.sundr.model.utils.Types.isAbstract;
 import static io.sundr.utils.Strings.capitalizeFirst;
 
 import java.io.File;
@@ -66,6 +65,7 @@ import io.sundr.builder.internal.BuilderContext;
 import io.sundr.builder.internal.BuilderContextManager;
 import io.sundr.builder.internal.functions.Construct;
 import io.sundr.builder.internal.functions.TypeAs;
+import io.sundr.functions.Singularize;
 import io.sundr.model.AnnotationRef;
 import io.sundr.model.Attributeable;
 import io.sundr.model.ClassRef;
@@ -96,7 +96,6 @@ import io.sundr.model.utils.Types;
 
 public class BuilderUtils {
 
-  private static final String OBJECT_FULLY_QUALIFIED_NAME = Object.class.getName();
   private static final String[] NON_INLINABLE_PACKAGES = { "java", "javax", "sun", "com.sun" };
   private static final List<String> ADDITIONALINLINABLE_ARGUMENTS = Arrays.asList(Class.class.getCanonicalName(),
       File.class.getCanonicalName(), Path.class.getCanonicalName());
@@ -560,6 +559,25 @@ public class BuilderUtils {
 
   private static final String[] GENERIC_NAMES = { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O",
       "P", "Q", "R", "S" };
+
+  /**
+   * Create a qualified name for the given property - if it is not a descendant, then just the capitalized
+   * name will be used.
+   */
+  public static String qualifyPropertyName(Property property, TypeRef typeRef, TypeDef originType) {
+    return qualifyPropertyName(property, typeRef, originType, false);
+  }
+
+  /**
+   * Create a qualified name for the given property. If useSingular is true the root property name will be changed
+   * to the singular form.
+   */
+  public static String qualifyPropertyName(Property property, TypeRef typeRef, TypeDef originType, boolean useSingular) {
+    return (property.hasAttribute(Constants.DESCENDANT_OF) ? BuilderUtils.fullyQualifiedNameDiff(typeRef, originType) : "")
+        + (useSingular
+            ? Singularize.FUNCTION.apply(property.getNameCapitalized())
+            : property.getNameCapitalized());
+  }
 
   public static String fullyQualifiedNameDiff(TypeRef typeRef, TypeDef originType) {
     Map<String, String> map = DefinitionRepository.getRepository().getReferenceMap();

--- a/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
+++ b/tests/shapes/src/test/java/io/sundr/examples/shapes/ShapesTest.java
@@ -17,6 +17,7 @@
 package io.sundr.examples.shapes;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Collections;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -390,8 +392,12 @@ public class ShapesTest {
 
   @Test
   public void testBuildablePropertyMethodNames() throws Exception {
-    assertNotNull(CanvasBuilder.class.getMethod("withNewV1", null));
-    assertNotNull(CanvasBuilder.class.getMethod("withNewV2", null));
+    CanvasBuilder builder = new CanvasBuilder();
+    // should contain V1 begin / end methods
+    builder.withNewV1().endV1();
+    builder.withNewV2().endV2();
+    // should not contain any methods with an additional prefix
+    assertFalse(Stream.of(CanvasBuilder.class.getMethods()).map(m -> m.getName()).anyMatch(n -> n.contains("V1V1") || n.contains("V2V2")));
   }
 
 }


### PR DESCRIPTION
I should have realized all of the calls to the qualification logic were problematic.  This should ensure consistency and push a little more of the logic to common methods.

closes: #451