### PR TITLE
task: making the baseline java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8,11,17,21]
+        java: [11,17,21]
         profile: [normal, with-swagger]
     steps:
       - name: Checkout
@@ -42,7 +42,4 @@ jobs:
           cache: 'maven'
       - name: Build Project
         run: |
-          if [ -f $JAVA_HOME/lib/tools.jar ]; then
-            ./mvnw install:install-file -Dfile=$JAVA_HOME/lib/tools.jar -DgroupId=com.sun -DartifactId=tools -Dversion=8 -Dpackaging=jar -P${{ matrix.profile }};
-          fi
           ./mvnw ${MAVEN_ARGS} clean install -Pwith-examples -Dformat.skip=true

--- a/.github/workflows/downstream-check.yml
+++ b/.github/workflows/downstream-check.yml
@@ -32,7 +32,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'downstream-check') || github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     strategy:
       matrix:
-        java: [8]
+        java: [11]
         profile: [normal]
     steps:
       - name: Checkout
@@ -42,11 +42,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - name: Install prerequisites
-        run: |
-          if [ -f $JAVA_HOME/lib/tools.jar ]; then
-            ./mvnw install:install-file -Dfile=$JAVA_HOME/lib/tools.jar -DgroupId=com.sun -DartifactId=tools -Dversion=8 -Dpackaging=jar -P${{ matrix.profile }};
-          fi
       - name: Build 
         run: ./mvnw ${MAVEN_ARGS} clean install -Dformat.skip=true
       - name: Build Kubernetes Client

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     name: release
     strategy:
       matrix:
-        java: [8]
+        java: [11]
         profile: [normal]
     if: ${{github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true}}
     steps:
@@ -31,18 +31,13 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
           server-id: oss-sonatype-staging
           server-username: OSS_SONATYPE_USERNAME
           server-password: OSS_SONATYPE_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
-      - name: Install prerequisites
-        run: |
-          if [ -f $JAVA_HOME/lib/tools.jar ]; then
-            ./mvnw install:install-file -Dfile=$JAVA_HOME/lib/tools.jar -DgroupId=com.sun -DartifactId=tools -Dversion=8 -Dpackaging=jar -P${{ matrix.profile }};
-          fi
       - name: Configure Git author
         run: |
           git config --local user.email "action@github.com"

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: release
     strategy:
       matrix:
-        java: [8]
+        java: [11]
         profile: [normal]
     steps:
       - uses: actions/checkout@v2
@@ -24,18 +24,13 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
           server-id: oss-sonatype-snapshots
           server-username: OSS_SONATYPE_USERNAME
           server-password: OSS_SONATYPE_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
-      - name: Install prerequisites
-        run: |
-          if [ -f $JAVA_HOME/lib/tools.jar ]; then
-            ./mvnw install:install-file -Dfile=$JAVA_HOME/lib/tools.jar -DgroupId=com.sun -DartifactId=tools -Dversion=8 -Dpackaging=jar -P${{ matrix.profile }};
-          fi
       - name: Maven snapshot release 
         run: |
           ./mvnw clean deploy -DskipTests -Dformat.skip=true

--- a/adapters/api/pom.xml
+++ b/adapters/api/pom.xml
@@ -24,7 +24,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.sundr</groupId>
     <artifactId>sundr-adapter-api</artifactId>
     <name>Sundrio :: Adapters :: API</name>
 
@@ -46,17 +45,4 @@
       </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/adapters/apt/pom.xml
+++ b/adapters/apt/pom.xml
@@ -62,17 +62,4 @@
 
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/adapters/reflect/pom.xml
+++ b/adapters/reflect/pom.xml
@@ -55,17 +55,4 @@
       </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/adapters/source-nodeps/pom.xml
+++ b/adapters/source-nodeps/pom.xml
@@ -24,7 +24,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.sundr</groupId>
     <artifactId>sundr-adapter-source-nodeps</artifactId>
     <name>Sundrio :: Adapter :: Source :: No deps - Uberjar</name>
 
@@ -87,19 +86,4 @@
       </dependency>
     </dependencies>
 
-    <profiles>
-        <profile>
-             <id>jdk9</id>
-             <activation>
-                 <jdk>[1,1.9)</jdk>
-             </activation>
-             <dependencies>
-                 <dependency>
-                     <groupId>com.sun</groupId>
-                     <artifactId>tools</artifactId>
-                     <optional>true</optional>
-                 </dependency>
-             </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/adapters/source/pom.xml
+++ b/adapters/source/pom.xml
@@ -50,17 +50,4 @@
       </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/adapters/testing/pom.xml
+++ b/adapters/testing/pom.xml
@@ -24,7 +24,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.sundr</groupId>
     <artifactId>sundr-adapter-testing</artifactId>
     <name>Sundrio :: Adapters :: Testing</name>
 
@@ -50,15 +49,6 @@
 
     <build>
         <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-jar-plugin</artifactId>

--- a/annotations/builder/pom.xml
+++ b/annotations/builder/pom.xml
@@ -23,7 +23,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.sundr</groupId>
     <artifactId>builder-annotations</artifactId>
     <name>Sundrio :: Annotations :: Builder</name>
 
@@ -153,21 +152,5 @@
         </dependency>
 
     </dependencies>
-
-    <profiles>
-        <profile>
-             <id>jdk9</id>
-             <activation>
-                 <jdk>[1,1.9)</jdk>
-             </activation>
-             <dependencies>
-                 <dependency>
-                     <groupId>com.sun</groupId>
-                     <artifactId>tools</artifactId>
-                     <optional>true</optional>
-                 </dependency>
-             </dependencies>
-        </profile>
-    </profiles>
 
 </project>

--- a/annotations/builder/src/it/buildable-concrete-collections/pom.xml
+++ b/annotations/builder/src/it/buildable-concrete-collections/pom.xml
@@ -31,8 +31,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/annotations/builder/src/it/inherited-generic-properties/pom.xml
+++ b/annotations/builder/src/it/inherited-generic-properties/pom.xml
@@ -31,8 +31,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/annotations/builder/src/it/lazy-buildable-collections/pom.xml
+++ b/annotations/builder/src/it/lazy-buildable-collections/pom.xml
@@ -31,8 +31,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/annotations/builder/src/it/lazy-collections/pom.xml
+++ b/annotations/builder/src/it/lazy-collections/pom.xml
@@ -31,8 +31,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/annotations/builder/src/it/lazy-maps/pom.xml
+++ b/annotations/builder/src/it/lazy-maps/pom.xml
@@ -31,8 +31,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/annotations/dsl/pom.xml
+++ b/annotations/dsl/pom.xml
@@ -23,7 +23,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.sundr</groupId>
     <artifactId>dsl-annotations</artifactId>
     <name>Sundrio :: Annotations :: DSL</name>
 
@@ -32,9 +31,16 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
                 <configuration>
-                    <compilerArgument>-proc:none</compilerArgument>
+                    <compilerArgs>
+                        <arg>--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                        <arg>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                        <arg>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                        <arg>--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                        <arg>--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                        <arg>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                        <arg>-proc:none</arg>
+                    </compilerArgs>                    
                 </configuration>
             </plugin>
         </plugins>
@@ -59,21 +65,5 @@
         </dependency>
 
     </dependencies>
-
-    <profiles>
-        <profile>
-             <id>jdk9</id>
-             <activation>
-                 <jdk>[1,1.9)</jdk>
-             </activation>
-             <dependencies>
-                 <dependency>
-                     <groupId>com.sun</groupId>
-                     <artifactId>tools</artifactId>
-                     <optional>true</optional>
-                 </dependency>
-             </dependencies>
-        </profile>
-    </profiles>
 
 </project>

--- a/annotations/resourcecify/pom.xml
+++ b/annotations/resourcecify/pom.xml
@@ -23,7 +23,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.sundr</groupId>
     <artifactId>resourcecify-annotations</artifactId>
     <name>Sundrio :: Annotations :: Resourcecify</name>
 
@@ -40,19 +39,4 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-             <id>jdk9</id>
-             <activation>
-                 <jdk>[1,1.9)</jdk>
-             </activation>
-             <dependencies>
-                 <dependency>
-                     <groupId>com.sun</groupId>
-                     <artifactId>tools</artifactId>
-                     <optional>true</optional>
-                 </dependency>
-             </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/codegen/st4-nodeps/pom.xml
+++ b/codegen/st4-nodeps/pom.xml
@@ -24,7 +24,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.sundr</groupId>
     <artifactId>sundr-codegen-st4-nodeps</artifactId>
     <name>Sundrio :: Code generation :: String Template 4 :: No deps - Uberjar</name>
 
@@ -89,19 +88,4 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-             <id>jdk9</id>
-             <activation>
-                 <jdk>[1,1.9)</jdk>
-             </activation>
-             <dependencies>
-                 <dependency>
-                     <groupId>com.sun</groupId>
-                     <artifactId>tools</artifactId>
-                     <optional>true</optional>
-                 </dependency>
-             </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/codegen/velocity-nodeps/pom.xml
+++ b/codegen/velocity-nodeps/pom.xml
@@ -24,7 +24,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.sundr</groupId>
     <artifactId>sundr-codegen-velocity-nodeps</artifactId>
     <name>Sundrio :: Code generation :: Velocity :: No deps - Uberjar</name>
 
@@ -99,19 +98,4 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-             <id>jdk9</id>
-             <activation>
-                 <jdk>[1,1.9)</jdk>
-             </activation>
-             <dependencies>
-                 <dependency>
-                     <groupId>com.sun</groupId>
-                     <artifactId>tools</artifactId>
-                     <optional>true</optional>
-                 </dependency>
-             </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/codegen/velocity/pom.xml
+++ b/codegen/velocity/pom.xml
@@ -24,7 +24,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.sundr</groupId>
     <artifactId>sundr-codegen-velocity</artifactId>
     <name>Sundrio :: Code generation :: Velocity</name>
 
@@ -49,19 +48,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-             <id>jdk9</id>
-             <activation>
-                 <jdk>[1,1.9)</jdk>
-             </activation>
-             <dependencies>
-                 <dependency>
-                     <groupId>com.sun</groupId>
-                     <artifactId>tools</artifactId>
-                     <optional>true</optional>
-                 </dependency>
-             </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/examples/builder/hello-builder-package/pom.xml
+++ b/examples/builder/hello-builder-package/pom.xml
@@ -33,8 +33,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/builder/hello-lombok/pom.xml
+++ b/examples/builder/hello-lombok/pom.xml
@@ -34,8 +34,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/builder/hello-nested/pom.xml
+++ b/examples/builder/hello-nested/pom.xml
@@ -33,8 +33,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/builder/hello-world/pom.xml
+++ b/examples/builder/hello-world/pom.xml
@@ -33,8 +33,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/curator-dsl/pom.xml
+++ b/examples/curator-dsl/pom.xml
@@ -37,8 +37,8 @@
                 <!-- Upgrading to 3.x breaks the build with unkown error -->
                 <version>2.3.2</version> 
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/curator-dsl/validation/pom.xml
+++ b/examples/curator-dsl/validation/pom.xml
@@ -28,21 +28,6 @@
     <artifactId>validation</artifactId>
     <name>Sundrio :: Examples :: Validation</name>
 
-
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>io.sundr</groupId>

--- a/examples/kubernetes-dsl/pom.xml
+++ b/examples/kubernetes-dsl/pom.xml
@@ -35,8 +35,8 @@
                 <!-- Upgrading to 3.x breaks the build with unkown error -->
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/validation/pom.xml
+++ b/examples/validation/pom.xml
@@ -28,21 +28,6 @@
     <artifactId>validation</artifactId>
     <name>Sundrio :: Examples :: Validation</name>
 
-
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>io.sundr</groupId>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -23,7 +23,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.sundr</groupId>
     <artifactId>sundr-maven-plugin</artifactId>
     <name>Sundrio :: Maven Plugin</name>
     <packaging>maven-plugin</packaging>

--- a/maven-plugin/src/main/java/io/sundr/maven/AbstractSundrioMojo.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/AbstractSundrioMojo.java
@@ -36,7 +36,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.invoker.DefaultInvocationRequest;
 import org.apache.maven.shared.invoker.DefaultInvoker;
-import org.apache.maven.shared.invoker.InvocationRequest;
 import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.Invoker;
 import org.apache.maven.shared.invoker.MavenInvocationException;
@@ -112,12 +111,12 @@ public abstract class AbstractSundrioMojo extends AbstractMojo {
   void backGroundBuild(MavenProject project) throws MojoExecutionException {
     MavenExecutionRequest executionRequest = session.getRequest();
 
-    InvocationRequest request = new DefaultInvocationRequest();
+    DefaultInvocationRequest request = new DefaultInvocationRequest();
     request.setBaseDirectory(project.getBasedir());
     request.setPomFile(project.getFile());
     request.setGoals(executionRequest.getGoals());
     request.setRecursive(false);
-    request.setInteractive(false);
+    request.setBatchMode(false);
 
     request.setProfiles(executionRequest.getActiveProfiles());
     request.setProperties(executionRequest.getUserProperties());

--- a/maven-plugin/src/main/java/io/sundr/maven/BomDependencyGraph.java
+++ b/maven-plugin/src/main/java/io/sundr/maven/BomDependencyGraph.java
@@ -36,6 +36,11 @@ public class BomDependencyGraph implements ProjectDependencyGraph {
   }
 
   @Override
+  public List<MavenProject> getAllProjects() {
+    return projects;
+  }
+
+  @Override
   public List<MavenProject> getSortedProjects() {
     return projects;
   }

--- a/model/base/pom.xml
+++ b/model/base/pom.xml
@@ -35,17 +35,4 @@
       </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/model/builder/pom.xml
+++ b/model/builder/pom.xml
@@ -45,17 +45,4 @@
       </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/model/generator/pom.xml
+++ b/model/generator/pom.xml
@@ -49,17 +49,4 @@
       </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/model/repo/pom.xml
+++ b/model/repo/pom.xml
@@ -45,17 +45,4 @@
       </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/model/utils/pom.xml
+++ b/model/utils/pom.xml
@@ -56,17 +56,4 @@
       </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,10 @@
         <format.skip>false</format.skip>
         <javadoc.opts>-Xdoclint:none</javadoc.opts>
 
-        <maven.version>3.3.1</maven.version>
-        <maven.invoker.version>2.0.11</maven.invoker.version>
-        <maven-plugin-annotations.version>3.2</maven-plugin-annotations.version>
+        <maven.version>3.6.3</maven.version>
+        <maven.invoker.version>3.2.0</maven.invoker.version>
+        <maven-plugin-annotations.version>3.6.4</maven-plugin-annotations.version>
 
-        <sun.tools.version>8</sun.tools.version>
         <validation.api.version>2.0.1.Final</validation.api.version>
         <velocity.version>1.7</velocity.version>
         <st4.version>4.3</st4.version>
@@ -78,7 +77,7 @@
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
         <maven-invoker-plugin.version>3.2.2</maven-invoker-plugin.version>
-        <maven-plugin-plugin.version>3.5</maven-plugin-plugin.version>
+        <maven-plugin-plugin.version>3.6.4</maven-plugin-plugin.version>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
 
         <!-- Release Plugins -->
@@ -136,8 +135,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                     <!-- The option below starting causing `Unknown compilation error` as soon as SourceVersion annotations were removed
                          in favor of SourceVersion.latest().
                          According to: https://stackoverflow.com/questions/56646698/what-causes-an-unknown-compilation-problem-occurred the
@@ -147,6 +146,26 @@
                         <arg>-Werror</arg>
                     </compilerArgs-->
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>(11,)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -191,6 +210,20 @@
                 <version>${hamcrest.version}</version>
                 <scope>test</scope>
             </dependency>
+            
+            <dependency>
+                <groupId>com.google.testing.compile</groupId>
+                <artifactId>compile-testing</artifactId>
+                <version>${compile-testing.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.sun</groupId>
+                        <artifactId>tools</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            
         </dependencies>
     </dependencyManagement>
 
@@ -362,50 +395,6 @@
               </plugin>
             </plugins>
           </build>
-        </profile>
-        <profile>
-             <id>jdk9</id>
-             <activation>
-                 <jdk>[1,1.9)</jdk>
-             </activation>
-             <dependencyManagement>
-                 <dependencies>
-                     <dependency>
-                         <groupId>com.sun</groupId>
-                         <artifactId>tools</artifactId>
-                         <version>${sun.tools.version}</version>
-                         <optional>true</optional>
-                     </dependency>
-                   <dependency>
-                     <groupId>com.google.testing.compile</groupId>
-                     <artifactId>compile-testing</artifactId>
-                     <version>${compile-testing.version}</version>
-                     <scope>test</scope>
-                   </dependency>
-                 </dependencies>
-             </dependencyManagement>
-        </profile>
-        <profile>
-             <id>jdk9+</id>
-             <activation>
-                 <jdk>[1.9,)</jdk>
-             </activation>
-             <dependencyManagement>
-                 <dependencies>
-                   <dependency>
-                     <groupId>com.google.testing.compile</groupId>
-                     <artifactId>compile-testing</artifactId>
-                     <version>${compile-testing.version}</version>
-                     <scope>test</scope>
-                     <exclusions>
-                       <exclusion>
-                         <groupId>com.sun</groupId>
-                         <artifactId>tools</artifactId>
-                       </exclusion>
-                     </exclusions>
-                   </dependency>
-                 </dependencies>
-             </dependencyManagement>
         </profile>
         <profile>
              <id>with-examples</id>

--- a/readme.md
+++ b/readme.md
@@ -310,13 +310,7 @@ The project also includes so modules that put the code model & adapters into the
 
 # Compiling 
 
-The project is meant to be compiled using java 8.
-The project internally is using `com.sun:tools` which is found under `$JAVA_HOME/lib/tools.jar` for all java version before 11.
-To avoid referencing to that path, which is known to cause issues, its required to install it your maven local repository.
-
-    mvn install:install-file -Dfile=$JAVA_HOME/lib/tools.jar -DgroupId=com.sun -DartifactId=tools -Dversion=8 -Dpackaging=jar
-
-*Note*: To just use this project no action is required as the dependency is only needed to compile sundrio itself.
+The project is meant to be compiled using java 11.
 
 # Projects using sundrio
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.sundr</groupId>
     <artifactId>tests</artifactId>
     <name>Sundrio :: Tests</name>
     <packaging>pom</packaging>

--- a/tests/shapes-extension/pom.xml
+++ b/tests/shapes-extension/pom.xml
@@ -27,21 +27,6 @@
     <artifactId>shapes-extension</artifactId>
     <name>Sundrio :: Tests :: Shapes extension</name>
 
-
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>io.sundr.tests</groupId>

--- a/tests/shapes/pom.xml
+++ b/tests/shapes/pom.xml
@@ -28,21 +28,6 @@
     <artifactId>shapes</artifactId>
     <name>Sundrio :: Tests :: Shapes</name>
 
-
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>io.sundr</groupId>

--- a/tests/visitor-filtering/pom.xml
+++ b/tests/visitor-filtering/pom.xml
@@ -28,21 +28,6 @@
     <artifactId>visitor-filtering</artifactId>
     <name>Sundrio :: Tests :: Visitor Filtering</name>
 
-
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>io.sundr</groupId>

--- a/tests/visitor/pom.xml
+++ b/tests/visitor/pom.xml
@@ -28,21 +28,6 @@
     <artifactId>visitor</artifactId>
     <name>Sundrio :: Tests :: Visitor</name>
 
-
-    <build>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>io.sundr</groupId>


### PR DESCRIPTION
closes: #466

Added an enforcer that the java version must be 11+  - that can be removed if it doesn't seem necessary.

maven-plugin-plugin needed to be updated as well, so I did a little alignment / update of the maven related dependencies - but didn't try to push it all the way to the latest.

removed any overrides that didn't seem to be needed given that they are coming from the parent.

had to add some compiler args to directly reference the com.sun stuff in the dsl test.