### PR TITLE
chore: prepare for 0.200.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Sundrio
 release:
-  current-version: 0.103.1
+  current-version: 0.200.0
   next-version: 999-SNAPSHOT


### PR DESCRIPTION
As we baseline to java 11 I am bumping to 0.200.0.
