### PR TITLE
test: (disabled)reproducer test for duplicate builder methods fluent

### DIFF
--- a/tests/buildable-duplicates/pom.xml
+++ b/tests/buildable-duplicates/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Copyright 2018 The original authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tests</artifactId>
+        <groupId>io.sundr</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.sundr.tests</groupId>
+    <artifactId>buildalbe-duplicates</artifactId>
+    <name>Sundrio :: Tests :: Buildable Duplicates</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.sundr</groupId>
+            <artifactId>builder-annotations</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/buildable-duplicates/src/main/java/io/sundr/tests/Object.java
+++ b/tests/buildable-duplicates/src/main/java/io/sundr/tests/Object.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+**/
+
+package io.sundr.tests;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.sundr.tests.builder")
+public class Object implements Resource {
+
+  private final ObjectSpec spec;
+  private final Resource status;
+
+  public Object(ObjectSpec spec, Resource status) {
+    this.spec = spec;
+    this.status = status;
+  }
+
+  public ObjectSpec getSpec() {
+    return spec;
+  }
+
+  public Resource getStatus() {
+    return status;
+  }
+}

--- a/tests/buildable-duplicates/src/main/java/io/sundr/tests/ObjectSpec.java
+++ b/tests/buildable-duplicates/src/main/java/io/sundr/tests/ObjectSpec.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+**/
+
+package io.sundr.tests;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.sundr.tests.builder")
+
+public class ObjectSpec implements Resource {
+
+  private final String specificResourceName;
+
+  public ObjectSpec(String specificResourceName) {
+    this.specificResourceName = specificResourceName;
+  }
+
+  public String getSpecificResourceName() {
+    return specificResourceName;
+  }
+}

--- a/tests/buildable-duplicates/src/main/java/io/sundr/tests/Resource.java
+++ b/tests/buildable-duplicates/src/main/java/io/sundr/tests/Resource.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+**/
+
+package io.sundr.tests;
+
+import java.io.Serializable;
+
+public interface Resource extends Serializable {
+}

--- a/tests/buildable-duplicates/src/main/java/io/sundr/tests/Root.java
+++ b/tests/buildable-duplicates/src/main/java/io/sundr/tests/Root.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+**/
+
+package io.sundr.tests;
+
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * This class is the Root class where the buildable processing starts.
+ */
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.sundr.tests.builder")
+public class Root implements Resource {
+
+  private final Resource spec;
+  private final Resource status;
+
+  public Root(Resource spec, Resource status) {
+    this.spec = spec;
+    this.status = status;
+  }
+
+  public Resource getSpec() {
+    return spec;
+  }
+
+  public Resource getStatus() {
+    return status;
+  }
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -30,6 +30,8 @@
 
     <modules>
         <module>arrays</module>
+        <!-- TODO: Disabled until https://github.com/sundrio/sundrio/issues/170 is fixed -->
+<!--        <module>buildable-duplicates</module>-->
         <module>buildable-fields</module>
         <module>buildable-pojos</module>
         <module>shapes</module>


### PR DESCRIPTION
This is a reproducer test for what's more or less described in #170
It's disabled at the pom level (integration test) so that it can be merged before tackling the issue.

This is a big problem for the new generator approach in the Kubernetes Client (https://github.com/fabric8io/kubernetes-client/issues/6130)
As reported in https://github.com/fabric8io/kubernetes-client/issues/6320

The kind of naming and class structure as defined in this tests generates both duplicate builder methods and nested classes.

In this case, the generated `RootFluent` will contain:

```java
// 60
  public ObjectSpecNested<A> withNewObjectSpec() {
    return new ObjectSpecNested(null);
  }
// 72
  public ObjectSpecNested<A> withNewObjectSpec() {
    return new ObjectSpecNested(null);
  }
// 177
  public class ObjectSpecNested<N> extends ObjectSpecFluent<ObjectSpecNested<N>> implements Nested<N>{ //...
// 193
  public class ObjectSpecNested<N> extends ObjectFluent<ObjectSpecNested<N>> implements Nested<N>{ //...
```

A slight change in the name of the classes (Object or ObjectSpec) prevents the issue from happening.