### PR TITLE
Iss170

### DIFF
--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/Descendants.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/Descendants.java
@@ -25,6 +25,8 @@ import static io.sundr.model.utils.Collections.IS_MAP;
 import static io.sundr.utils.Strings.compact;
 import static io.sundr.utils.Strings.deCapitalizeFirst;
 
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -55,6 +57,7 @@ public class Descendants {
 
   public static final Function<TypeDef, Set<TypeDef>> BUILDABLE_DECENDANTS = FunctionFactory
       .cache(new Function<TypeDef, Set<TypeDef>>() {
+        @Override
         public Set<TypeDef> apply(TypeDef item) {
           if (item.equals(TypeDef.OBJECT)) {
             return new LinkedHashSet<TypeDef>();
@@ -80,6 +83,7 @@ public class Descendants {
    */
   public static Function<Property, Set<Property>> PROPERTY_BUILDABLE_DESCENDANTS = FunctionFactory
       .wrap(new Function<Property, Set<Property>>() {
+        @Override
         public Set<Property> apply(Property property) {
           Set<Property> result = new LinkedHashSet<Property>();
           if (isNestingIgnored(property)) {
@@ -94,88 +98,61 @@ public class Descendants {
             if (unwrapped instanceof ClassRef) {
               ClassRef candidate = (ClassRef) unwrapped;
 
-              for (TypeDef descendant : BUILDABLE_DECENDANTS.apply(GetDefinition.of(candidate))) {
-                ClassRef descendantRef = new ClassRefBuilder(descendant.toInternalReference())
-                    .build();
-
-                if (isNestingFiltered(property, descendantRef)) {
-                  continue;
-                } else if (origin != null && (origin.getName().equals(descendant.getName())
-                    && !origin.getPackageName().equals(descendant.getPackageName()))) {
-                  //We don't want to have a class that references a descendant with the same name in an other package. It's an extreme case and will not work.
-                  continue;
-                }
-
-                ClassRef collectionType = new ClassRefBuilder((ClassRef) baseType)
-                    .withArguments(descendantRef)
-                    .build();
-
-                String propertyName = compact(deCapitalizeFirst(descendant.getName()), property.getNameCapitalized());
-                result.add(new PropertyBuilder(property)
-                    .withName(propertyName)
-                    .withTypeRef(collectionType)
-                    .addToAttributes(DESCENDANT_OF, property)
-                    .addToAttributes(BUILDABLE_ENABLED, true)
-                    .accept(new InitEnricher())
-                    .build());
-              }
+              addDescendents(property, result, origin, candidate,
+                  ref -> new ClassRefBuilder((ClassRef) baseType).withArguments(ref).build());
             }
           } else if (IS_MAP.apply(baseType)) {
             TypeRef unwrapped = TypeAs.UNWRAP_MAP_VALUE_OF.apply(baseType);
             if (unwrapped instanceof ClassRef) {
               ClassRef candidate = (ClassRef) unwrapped;
 
-              for (TypeDef descendant : BUILDABLE_DECENDANTS.apply(GetDefinition.of(candidate))) {
-                ClassRef descendantRef = new ClassRefBuilder(descendant.toInternalReference())
-                    .build();
-
-                if (isNestingFiltered(property, descendantRef)) {
-                  continue;
-                } else if (origin.getName().equals(descendant.getName())
-                    && !origin.getPackageName().equals(descendant.getPackageName())) {
-                  //We don't want to have a class that references a descendant with the same name in an other package. It's an extreme case and will not work.
-                  continue;
-                }
-
-                ClassRef mapType = new ClassRefBuilder((ClassRef) baseType)
-                    .withArguments(TypeAs.UNWRAP_MAP_KEY_OF.apply(baseType), descendantRef)
-                    .build();
-
-                String propertyName = compact(deCapitalizeFirst(descendant.getName()), property.getNameCapitalized());
-                result.add(new PropertyBuilder(property)
-                    .withName(propertyName)
-                    .withTypeRef(mapType)
-                    .addToAttributes(DESCENDANT_OF, property)
-                    .addToAttributes(BUILDABLE_ENABLED, true)
-                    .accept(new InitEnricher())
-                    .build());
-              }
+              addDescendents(property, result, origin, candidate, ref -> new ClassRefBuilder((ClassRef) baseType)
+                  .withArguments(TypeAs.UNWRAP_MAP_KEY_OF.apply(baseType), ref).build());
             }
           } else if (baseType instanceof ClassRef) {
             ClassRef candidate = (ClassRef) baseType;
-            for (TypeDef descendant : BUILDABLE_DECENDANTS.apply(GetDefinition.of(candidate))) {
-              ClassRef descendantRef = new ClassRefBuilder(descendant.toInternalReference())
-                  .build();
 
-              if (isNestingFiltered(property, descendantRef)) {
-                continue;
-              } else if (origin != null && (origin.getName().equals(descendant.getName())
-                  && !origin.getPackageName().equals(descendant.getPackageName()))) {
-                //We don't want to have a class that references a descendant with the same name in an other package. It's an extreme case and will not work.
-                continue;
-              }
-
-              String propertyName = compact(deCapitalizeFirst(descendant.getName()), property.getNameCapitalized());
-              result.add(new PropertyBuilder(property)
-                  .withName(propertyName)
-                  .withTypeRef(descendantRef)
-                  .addToAttributes(DESCENDANT_OF, property)
-                  .addToAttributes(BUILDABLE_ENABLED, true)
-                  .accept(new InitEnricher())
-                  .build());
-            }
+            addDescendents(property, result, origin, candidate, Function.identity());
           }
           return result;
+        }
+
+        private void addDescendents(Property property, Set<Property> result, TypeDef origin, ClassRef candidate,
+            Function<ClassRef, ClassRef> typeFunction) {
+          Map<String, Boolean> nameConflicts = new HashMap<>();
+
+          LinkedHashMap<TypeDef, ClassRef> decendents = new LinkedHashMap<>();
+
+          for (TypeDef descendant : BUILDABLE_DECENDANTS.apply(GetDefinition.of(candidate))) {
+            ClassRef descendantRef = new ClassRefBuilder(descendant.toInternalReference())
+                .build();
+
+            if (isNestingFiltered(property, descendantRef)) {
+              continue;
+            } else if (origin != null && (origin.getName().equals(descendant.getName())
+                && !origin.getPackageName().equals(descendant.getPackageName()))) {
+              //We don't want to have a class that references a descendant with the same name in an other package. It's an extreme case and will not work.
+              continue;
+            }
+
+            decendents.put(descendant, descendantRef);
+            String compactName = compact(deCapitalizeFirst(descendant.getName()), property.getNameCapitalized());
+            nameConflicts.merge(compactName, false, (b1, b2) -> true);
+          }
+
+          for (Map.Entry<TypeDef, ClassRef> entry : decendents.entrySet()) {
+            String propertyName = compact(deCapitalizeFirst(entry.getKey().getName()), property.getNameCapitalized());
+            if (nameConflicts.get(propertyName)) {
+              propertyName = deCapitalizeFirst(entry.getKey().getName()) + property.getNameCapitalized();
+            }
+            result.add(new PropertyBuilder(property)
+                .withName(propertyName)
+                .withTypeRef(typeFunction.apply(entry.getValue()))
+                .addToAttributes(DESCENDANT_OF, property)
+                .addToAttributes(BUILDABLE_ENABLED, true)
+                .accept(new InitEnricher())
+                .build());
+          }
         }
       });
 

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToMethod.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToMethod.java
@@ -276,6 +276,7 @@ class ToMethod {
 
   static final Function<Property, Method> WITH = FunctionFactory.cache(new Function<Property, Method>() {
 
+    @Override
     public Method apply(Property property) {
       TypeRef returnType = property.hasAttribute(GENERIC_TYPE_REF) ? property.getAttribute(GENERIC_TYPE_REF) : T_REF;
       String methodName = "with" + property.getNameCapitalized();
@@ -296,7 +297,6 @@ class ToMethod {
 
     private List<Statement> getStatements(Property property, List<ClassRef> alsoImport) {
       TypeRef returnType = property.hasAttribute(GENERIC_TYPE_REF) ? property.getAttribute(GENERIC_TYPE_REF) : T_REF;
-      String argumentName = property.getName();
       String fieldName = property.getName();
       TypeRef type = property.getTypeRef();
       TypeRef unwrapped = combine(UNWRAP_COLLECTION_OF, UNWRAP_ARRAY_OF, UNWRAP_OPTIONAL_OF).apply(property.getTypeRef());
@@ -358,7 +358,6 @@ class ToMethod {
 
       if (isBuildable(unwrapped) && !isAbstract(unwrapped)) {
         ClassRef builder = BUILDER_REF.apply((ClassRef) unwrapped);
-        String builderClass = builder.getFullyQualifiedName();
         statements.add(new If(property.toReference().notNull(),
             new Block(new This().property(property).assignNew(builder, property.toReference()),
                 new This().property("_visitables").call("get", ValueRef.from(property.getName())).call("add",
@@ -455,7 +454,7 @@ class ToMethod {
             .withNewBlock()
             .withStatements(
                 new If(property.toReference().isNull().or(property.toReference().call("isPresent").not()),
-                    new This().property(property).assign(Expression.call((ClassRef) property.getTypeRef(), "empty")),
+                    new This().property(property).assign(Expression.call(property.getTypeRef(), "empty")),
 
                     isBuildable(unwrapped) && !isAbstract(unwrapped)
                         ? new Block(
@@ -698,6 +697,7 @@ class ToMethod {
 
   static final Function<Property, List<Method>> ADD_TO_COLLECTION = FunctionFactory
       .cache(new Function<Property, List<Method>>() {
+        @Override
         public List<Method> apply(final Property property) {
           List<Method> methods = new ArrayList<>();
           TypeRef baseType = UNWRAP_COLLECTION_OF.apply(property.getTypeRef());
@@ -848,12 +848,13 @@ class ToMethod {
 
   static final Function<Property, List<Method>> REMOVE_FROM_COLLECTION = FunctionFactory
       .cache(new Function<Property, List<Method>>() {
+        @Override
         public List<Method> apply(final Property property) {
           List<Method> methods = new ArrayList<>();
           ClassRef baseType = (ClassRef) UNWRAP_COLLECTION_OF.apply(property.getTypeRef());
           TypeDef originTypeDef = property.getAttribute(Constants.ORIGIN_TYPEDEF);
 
-          TypeRef builderType = VISITABLE_BUILDER_REF.apply((ClassRef) baseType);
+          TypeRef builderType = VISITABLE_BUILDER_REF.apply(baseType);
           Property builderProperty = new PropertyBuilder(property).withName("builder").withTypeRef(builderType).build();
 
           TypeRef returnType = property.hasAttribute(GENERIC_TYPE_REF) ? property.getAttribute(GENERIC_TYPE_REF) : T_REF;
@@ -1537,6 +1538,7 @@ class ToMethod {
   }
 
   static final Function<Property, Method> AND = new Function<Property, Method>() {
+    @Override
     public Method apply(Property property) {
       String classPrefix = getClassPrefix(property);
 

--- a/annotations/dsl/src/main/java/io/sundr/dsl/internal/type/functions/Combine.java
+++ b/annotations/dsl/src/main/java/io/sundr/dsl/internal/type/functions/Combine.java
@@ -58,6 +58,7 @@ import io.sundr.utils.Strings;
 public class Combine {
 
   public static Function<Collection<ClassRef>, TypeDef> TYPEREFS = new Function<Collection<ClassRef>, TypeDef>() {
+    @Override
     public TypeDef apply(Collection<ClassRef> alternatives) {
       String key = createKeyForClasses(alternatives);
       if (combinations.containsKey(key)) {
@@ -121,6 +122,7 @@ public class Combine {
 
   public static Function<Collection<TypeDef>, TypeDef> TYPEDEFS = new Function<Collection<TypeDef>, TypeDef>() {
 
+    @Override
     public TypeDef apply(Collection<TypeDef> alternatives) {
       String key = createKeyForTypes(alternatives);
       if (combinations.containsKey(key)) {
@@ -182,32 +184,11 @@ public class Combine {
     }
   };
 
-  public static final Function<Collection<TypeDef>, String> TYPEDEFS_TO_NAME = new Function<Collection<TypeDef>, String>() {
-    public String apply(Collection<TypeDef> types) {
-      final Function<TypeDef, String> toString = new Function<TypeDef, String>() {
-        public String apply(TypeDef item) {
-          return stripSuffix(item.getName());
-        }
-      };
-
-      final String prefix = Strings.getPrefix(types, toString);
-
-      return toInterfaceName(prefix + Strings.compact("", Strings.join(types, new Function<TypeDef, String>() {
-        public String apply(TypeDef item) {
-          String str = stripPrefix(stripSuffix(item.getName()));
-          if (str.length() > prefix.length()) {
-            return str.substring(prefix.length());
-          } else {
-            return str;
-          }
-        }
-      }, "")));
-    }
-  };
-
   public static final Function<Collection<ClassRef>, String> CLASSREFS_TO_NAME = new Function<Collection<ClassRef>, String>() {
+    @Override
     public String apply(Collection<ClassRef> types) {
       final Function<ClassRef, String> toString = new Function<ClassRef, String>() {
+        @Override
         public String apply(ClassRef item) {
           return stripSuffix(item.getName());
         }
@@ -216,6 +197,7 @@ public class Combine {
       final String prefix = Strings.getPrefix(types, toString);
 
       return toInterfaceName(prefix + Strings.compact("", Strings.join(types, new Function<ClassRef, String>() {
+        @Override
         public String apply(ClassRef item) {
           String str = stripPrefix(stripSuffix(item.getName()));
           if (str.length() > prefix.length()) {
@@ -230,6 +212,7 @@ public class Combine {
 
   public static final Function<List<ClassRef>, String> CLASSREFS_TO_PACKAGE = new Function<List<ClassRef>, String>() {
 
+    @Override
     public String apply(List<ClassRef> types) {
       Iterator<ClassRef> iterator = types.iterator();
       if (iterator.hasNext()) {
@@ -328,11 +311,13 @@ public class Combine {
   private static String createKeyForTypes(Collection<TypeDef> alternatives) {
     List<TypeDef> clazzes = new LinkedList<TypeDef>(alternatives);
     Collections.sort(clazzes, new Comparator<TypeDef>() {
+      @Override
       public int compare(TypeDef left, TypeDef right) {
         return left.getFullyQualifiedName().compareTo(right.getFullyQualifiedName());
       }
     });
     return Strings.join(clazzes, new Function<TypeDef, String>() {
+      @Override
       public String apply(TypeDef item) {
         return item.getFullyQualifiedName();
       }

--- a/tests/buildable-duplicates/pom.xml
+++ b/tests/buildable-duplicates/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Copyright 2018 The original authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tests</artifactId>
+        <groupId>io.sundr</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.sundr.tests</groupId>
+    <artifactId>buildalbe-duplicates</artifactId>
+    <name>Sundrio :: Tests :: Buildable Duplicates</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.sundr</groupId>
+            <artifactId>builder-annotations</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/buildable-duplicates/src/main/java/io/sundr/tests/Object.java
+++ b/tests/buildable-duplicates/src/main/java/io/sundr/tests/Object.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+**/
+
+package io.sundr.tests;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.sundr.tests.builder")
+public class Object implements Resource {
+
+  private final ObjectSpec spec;
+  private final Resource status;
+
+  public Object(ObjectSpec spec, Resource status) {
+    this.spec = spec;
+    this.status = status;
+  }
+
+  public ObjectSpec getSpec() {
+    return spec;
+  }
+
+  public Resource getStatus() {
+    return status;
+  }
+}

--- a/tests/buildable-duplicates/src/main/java/io/sundr/tests/ObjectSpec.java
+++ b/tests/buildable-duplicates/src/main/java/io/sundr/tests/ObjectSpec.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+**/
+
+package io.sundr.tests;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.sundr.tests.builder")
+
+public class ObjectSpec implements Resource {
+
+  private final String specificResourceName;
+
+  public ObjectSpec(String specificResourceName) {
+    this.specificResourceName = specificResourceName;
+  }
+
+  public String getSpecificResourceName() {
+    return specificResourceName;
+  }
+}

--- a/tests/buildable-duplicates/src/main/java/io/sundr/tests/Resource.java
+++ b/tests/buildable-duplicates/src/main/java/io/sundr/tests/Resource.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+**/
+
+package io.sundr.tests;
+
+import java.io.Serializable;
+
+public interface Resource extends Serializable {
+}

--- a/tests/buildable-duplicates/src/main/java/io/sundr/tests/Root.java
+++ b/tests/buildable-duplicates/src/main/java/io/sundr/tests/Root.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+**/
+
+package io.sundr.tests;
+
+import io.sundr.builder.annotations.Buildable;
+
+/**
+ * This class is the Root class where the buildable processing starts.
+ */
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = true, lazyCollectionInitEnabled = false, builderPackage = "io.sundr.tests.builder")
+public class Root implements Resource {
+
+  private final Resource spec;
+  private final Resource status;
+
+  public Root(Resource spec, Resource status) {
+    this.spec = spec;
+    this.status = status;
+  }
+
+  public Resource getSpec() {
+    return spec;
+  }
+
+  public Resource getStatus() {
+    return status;
+  }
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -30,8 +30,7 @@
 
     <modules>
         <module>arrays</module>
-        <!-- TODO: Disabled until https://github.com/sundrio/sundrio/issues/170 is fixed -->
-<!--        <module>buildable-duplicates</module>-->
+        <module>buildable-duplicates</module>
         <module>buildable-fields</module>
         <module>buildable-pojos</module>
         <module>shapes</module>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -30,6 +30,8 @@
 
     <modules>
         <module>arrays</module>
+        <!-- TODO: Disabled until https://github.com/sundrio/sundrio/issues/170 is fixed -->
+<!--        <module>buildable-duplicates</module>-->
         <module>buildable-fields</module>
         <module>buildable-pojos</module>
         <module>shapes</module>


### PR DESCRIPTION
@iocanel @manusa consolodates the descendant logic and adds a collision check as to whether compact names can be used. This is not a major overhaul, or a breaking change, just an incremental change to handle collisions that was otherwise broken.

