### PR TITLE
chore: prepare for 0.200.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Sundrio
 release:
-  current-version: 0.200.0
+  current-version: 0.200.1
   next-version: 999-SNAPSHOT


### PR DESCRIPTION
@iocanel I thought I had pushed my branch upstream from the prior pr, but unfortunatly hadn't done that either. Here's a new pr from a branch on the project repo. Should I also revert the prior prepare?