### PR TITLE
fix: vararg buildables in constructors

### DIFF
--- a/adapters/reflect/src/main/java/io/sundr/adapter/reflect/ClassToTypeDef.java
+++ b/adapters/reflect/src/main/java/io/sundr/adapter/reflect/ClassToTypeDef.java
@@ -205,6 +205,7 @@ public class ClassToTypeDef implements Function<Class, TypeDef> {
           .withModifiers(Modifiers.from(constructor.getModifiers()))
           .withArguments(arguments)
           .withParameters(parameters)
+          .withVarArgPreferred(constructor.isVarArgs())
           .withAnnotations(annotationRefs)
           .withExceptions(exceptionRefs)
           .build());
@@ -233,6 +234,7 @@ public class ClassToTypeDef implements Function<Class, TypeDef> {
           .withReturnType(typeToTypeRef.apply(method.getGenericReturnType()))
           .withArguments(arguments)
           .withParameters(parameters)
+          .withVarArgPreferred(method.isVarArgs())
           .withExceptions(exceptionRefs)
           .withAnnotations(annotationRefs)
           .withAttributes(attributes)

--- a/adapters/reflect/src/main/java/io/sundr/reflect/ClassTo.java
+++ b/adapters/reflect/src/main/java/io/sundr/reflect/ClassTo.java
@@ -328,6 +328,7 @@ public class ClassTo {
           .withModifiers(Modifiers.from(constructor.getModifiers()))
           .withArguments(arguments)
           .withParameters(parameters)
+          .withVarArgPreferred(constructor.isVarArgs())
           .withAnnotations(annotationRefs)
           .withExceptions(exceptionRefs)
           .build());
@@ -356,6 +357,7 @@ public class ClassTo {
           .withReturnType(TYPEREF.apply(method.getReturnType()))
           .withArguments(arguments)
           .withParameters(parameters)
+          .withVarArgPreferred(method.isVarArgs())
           .withExceptions(exceptionRefs)
           .withAnnotations(annotationRefs)
           .withAttributes(attributes)

--- a/adapters/source/src/main/java/io/sundr/adapter/source/TypeDeclarationToTypeDef.java
+++ b/adapters/source/src/main/java/io/sundr/adapter/source/TypeDeclarationToTypeDef.java
@@ -179,6 +179,7 @@ public class TypeDeclarationToTypeDef implements Function<TypeDeclaration, TypeD
           List<Property> arguments = new ArrayList<Property>();
           List<ClassRef> exceptions = new ArrayList<ClassRef>();
           List<AnnotationRef> ctorAnnotations = new ArrayList<AnnotationRef>();
+          Boolean preferVarArg = false;
 
           for (AnnotationExpr annotationExpr : constructorDeclaration.getAnnotations()) {
             ctorAnnotations.add(ANNOTATIONREF.apply(annotationExpr));
@@ -193,11 +194,17 @@ public class TypeDeclarationToTypeDef implements Function<TypeDeclaration, TypeD
               ctorParamAnnotations.add(ANNOTATIONREF.apply(annotationExpr));
             }
             TypeRef typeRef = checkAgainstTypeParamRef(typeToTypeRef.apply(parameter.getType()), parameters);
+
+            if (parameter.isVarArgs()) {
+              preferVarArg = true;
+              typeRef = typeRef.withDimensions(typeRef.getDimensions() + 1);
+            }
+
             arguments.add(new PropertyBuilder().withName(parameter.getId().getName()).withTypeRef(typeRef)
                 .withModifiers(Modifiers.from(parameter.getModifiers())).withAnnotations(ctorParamAnnotations).build());
           }
           constructors.add(new MethodBuilder().withModifiers(Modifiers.from(constructorDeclaration.getModifiers()))
-              .withExceptions(exceptions)
+              .withVarArgPreferred(preferVarArg).withExceptions(exceptions)
               .withArguments(arguments).withAnnotations(ctorAnnotations)
               .withBlock(BLOCK.apply(constructorDeclaration.getBlock())).build());
         }

--- a/annotations/builder/src/test/java/io/sundr/builder/internal/processor/VarArgsTest.java
+++ b/annotations/builder/src/test/java/io/sundr/builder/internal/processor/VarArgsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.sundr.builder.internal.processor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import io.sundr.adapter.api.AdapterContext;
+import io.sundr.adapter.source.utils.Sources;
+import io.sundr.builder.internal.functions.ClazzAs;
+import io.sundr.model.Kind;
+import io.sundr.model.Method;
+import io.sundr.model.RichTypeDef;
+import io.sundr.model.TypeDef;
+import io.sundr.model.repo.DefinitionRepository;
+import io.sundr.model.utils.TypeArguments;
+
+public class VarArgsTest extends AbstractProcessorTest {
+
+  private final AdapterContext context = AdapterContext.create(DefinitionRepository.getRepository());
+
+  RichTypeDef varArgsClassDef = TypeArguments.apply(Sources.readTypeDefFromResource("VarArgsClass.java", context));
+  RichTypeDef buildableItemDef = TypeArguments.apply(Sources.readTypeDefFromResource("BuildableItem.java", context));
+
+  @Test
+  public void testFluentWithBuildableVarArgs() {
+    TypeDef fluent = ClazzAs.FLUENT.apply(varArgsClassDef);
+    System.out.println(fluent);
+
+    assertEquals(Kind.CLASS, fluent.getKind());
+    assertEquals("VarArgsClassFluent", fluent.getName());
+
+    // Check if there's a method for handling the buildable var-args
+    boolean hasItemsMethod = false;
+    boolean hasAddToItemsMethod = false;
+    boolean hasRemoveFromItemsMethod = false;
+
+    for (Method method : fluent.getMethods()) {
+      if (method.getName().equals("withItems")) {
+        hasItemsMethod = true;
+      }
+      if (method.getName().equals("addToItems")) {
+        hasAddToItemsMethod = true;
+      }
+      if (method.getName().equals("removeFromItems")) {
+        hasRemoveFromItemsMethod = true;
+      }
+    }
+
+    System.out.println("Methods found:");
+    for (Method method : fluent.getMethods()) {
+      System.out.println("  " + method.getName() + "(" + method.getArguments() + ")");
+    }
+
+    assertTrue("Should have withItems method for buildable var-args", hasItemsMethod);
+    assertTrue("Should have addToItems method for buildable var-args", hasAddToItemsMethod);
+    assertTrue("Should have removeFromItems method for buildable var-args", hasRemoveFromItemsMethod);
+  }
+
+  @Test
+  public void testBuilderWithBuildableVarArgs() {
+    TypeDef builder = ClazzAs.BUILDER.apply(varArgsClassDef);
+    System.out.println(builder);
+
+    assertEquals(Kind.CLASS, builder.getKind());
+    assertEquals("VarArgsClassBuilder", builder.getName());
+
+    // Check if there's a build method that properly handles var-args
+    boolean hasBuildMethod = false;
+    for (Method method : builder.getMethods()) {
+      if (method.getName().equals("build")) {
+        hasBuildMethod = true;
+        break;
+      }
+    }
+
+    assertTrue("Should have build method", hasBuildMethod);
+  }
+}

--- a/annotations/builder/src/test/resources/BuildableItem.java
+++ b/annotations/builder/src/test/resources/BuildableItem.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package testpackage;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable
+public class BuildableItem {
+
+    private final String name;
+    private final String value;
+
+    public BuildableItem(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/annotations/builder/src/test/resources/VarArgsClass.java
+++ b/annotations/builder/src/test/resources/VarArgsClass.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package testpackage;
+
+import io.sundr.builder.annotations.Buildable;
+
+public class VarArgsClass {
+
+    private final String name;
+    private final BuildableItem[] items;
+
+    @Buildable
+    public VarArgsClass(String name, BuildableItem... items) {
+        this.name = name;
+        this.items = items;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public BuildableItem[] getItems() {
+        return items;
+    }
+}


### PR DESCRIPTION
Currently, buildables with varargs in constructor that are also buildable are failing.
The pull request addresses this issue.