### PR TITLE
Avoid conflict with Java package names (#1)

### DIFF
--- a/adapters/source/src/main/java/io/sundr/adapter/source/TypeDeclarationLookup.java
+++ b/adapters/source/src/main/java/io/sundr/adapter/source/TypeDeclarationLookup.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 import com.github.javaparser.ast.body.TypeDeclaration;
 
@@ -34,7 +33,7 @@ public class TypeDeclarationLookup implements TypeLookup<TypeDeclaration> {
   @Override
   public Optional<TypeDeclaration> forName(String fullyQualifiedName) {
     //1. Lookup resources
-    String resourceName = fullyQualifiedName.replaceAll(Pattern.quote("."), File.separator) + ".java";
+    String resourceName = fullyQualifiedName.replace(".", File.separator) + ".java";
     try {
       Optional<TypeDeclaration> typeDeclaration = Sources.readTypesFromResource(resourceName).stream().findFirst();
       if (typeDeclaration.isPresent()) {

--- a/adapters/source/src/main/java/io/sundr/adapter/source/utils/Project.java
+++ b/adapters/source/src/main/java/io/sundr/adapter/source/utils/Project.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -88,7 +87,7 @@ public class Project {
     String className = classNameOf(fqcn);
 
     if (packageName.isPresent()) {
-      Optional<Path> path = packageName.map(p -> p.replaceAll(Pattern.quote("."), File.separator))
+      Optional<Path> path = packageName.map(p -> p.replace(".", File.separator))
           .map(p -> new File(sourceRoot, p))
           .map(f -> new File(f, className + ".java"))
           .filter(File::exists)

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ClazzAs.java
@@ -18,6 +18,7 @@ package io.sundr.builder.internal.functions;
 
 import static io.sundr.builder.Constants.*;
 import static io.sundr.builder.internal.utils.BuilderUtils.*;
+import static io.sundr.model.Attributeable.ALSO_IMPORT;
 import static io.sundr.model.utils.Types.isAbstract;
 
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -269,6 +271,9 @@ public class ClazzAs {
                   .withName(fluent.getName())
                   .withParameters(parameters)
                   .withExtendsList(superClassRef)
+                  .addToAttributes(ALSO_IMPORT,
+                      Arrays.asList(ClassRef.forClass(Optional.class), ClassRef.forClass(Predicate.class),
+                          ClassRef.forClass(Objects.class)))
                   .withAnnotations(
                       new AnnotationRefBuilder().withClassRef(ClassRef.forName(SuppressWarnings.class.getCanonicalName()))
                           .addToParameters("value", "unchecked").build())

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToMethod.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/functions/ToMethod.java
@@ -1544,9 +1544,9 @@ class ToMethod {
   };
 
   private static String createWithNewStatement(Property property, String methodNameBase, String elseValue) {
-    return "return withNew" + methodNameBase + "Like(java.util.Optional.ofNullable("
+    return "return withNew" + methodNameBase + "Like(Optional.ofNullable("
         + getterOrBuildMethodName(property) + "())"
-        + (isOptional(property.getTypeRef()) ? ".flatMap(java.util.function.Function.identity())" : "")
+        + (isOptional(property.getTypeRef()) ? ".flatMap(Function.identity())" : "")
         + ".orElse(" + elseValue + "));";
   }
 

--- a/annotations/builder/src/main/java/io/sundr/builder/internal/utils/BuilderUtils.java
+++ b/annotations/builder/src/main/java/io/sundr/builder/internal/utils/BuilderUtils.java
@@ -837,7 +837,7 @@ public class BuilderUtils {
 
   public static List<Statement> toHashCode(Collection<Property> properties) {
     List<Statement> statements = new ArrayList<>();
-    statements.add(new StringStatement("return java.util.Objects.hash(" + Stream
+    statements.add(new StringStatement("return Objects.hash(" + Stream
         .concat(properties.stream().map(Property::getName), Stream.of("super.hashCode()")).collect(Collectors.joining(",  "))
         + ");"));
     return statements;
@@ -863,7 +863,7 @@ public class BuilderUtils {
                 .append(propertyName).append(") return false;").toString()));
       } else {
         statements.add(new StringStatement(new StringBuilder()
-            .append("if (!java.util.Objects.equals(").append(propertyName).append(", that.")
+            .append("if (!Objects.equals(").append(propertyName).append(", that.")
             .append(propertyName).append(")) return false;").append("\n")
             .toString()));
       }


### PR DESCRIPTION
When trying to use CRDS from OpenTelemetry, I encountered an issue with the generated code: Instrumentor has a field names java and some methods use FQDN beginning by java like java.util.Optional or java.util.Objects.
So I replaced FQDN by imports in the concerned Method/Class.
In addition, there were some calls using replaceAll with RegExp that were failing on Windows as File.separator was interpreted as the escape character without anything after.
I changed these calls by replace method that replace a given String by another. They do functionally the samething.